### PR TITLE
feat: configurable base branch and branch prefix for worktree creation

### DIFF
--- a/__tests__/actions/closeAction.test.ts
+++ b/__tests__/actions/closeAction.test.ts
@@ -302,9 +302,9 @@ describe('closeAction', () => {
         expect.anything()
       );
 
-      // Should delete branch
+      // Should delete branch (branch name is quoted for shell safety)
       expect(execSync).toHaveBeenCalledWith(
-        expect.stringContaining('git branch -D my-feature'),
+        expect.stringContaining('git branch -D "my-feature"'),
         expect.anything()
       );
     });

--- a/__tests__/baseBranchAndPrefix.test.ts
+++ b/__tests__/baseBranchAndPrefix.test.ts
@@ -1,0 +1,341 @@
+/**
+ * Tests for configurable base branch and branch prefix features.
+ *
+ * Test plan:
+ * 1. baseBranch setting: worktrees branch from configured base regardless of current checkout
+ * 2. branchPrefix setting: branch is prefixed but worktree dir uses unprefixed slug
+ * 3. Merge and close operations work correctly with prefixed branches
+ * 4. Orphaned worktree discovery works with prefixed panes
+ * 5. Settings API rejects invalid characters in baseBranch/branchPrefix
+ * 6. Nonexistent baseBranch shows clear error
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getPaneBranchName, isValidBranchName } from '../src/utils/git.js';
+
+// ─── Test 1 & 2: getPaneBranchName, slug/branchName separation ───
+
+describe('getPaneBranchName', () => {
+  it('returns branchName when set', () => {
+    const pane = {
+      id: 'dmux-1', slug: 'fix-auth', branchName: 'feat/fix-auth',
+      prompt: 'test', paneId: '%1',
+    };
+    expect(getPaneBranchName(pane)).toBe('feat/fix-auth');
+  });
+
+  it('falls back to slug when branchName is not set', () => {
+    const pane = {
+      id: 'dmux-1', slug: 'fix-auth',
+      prompt: 'test', paneId: '%1',
+    };
+    expect(getPaneBranchName(pane)).toBe('fix-auth');
+  });
+
+  it('falls back to slug when branchName is undefined', () => {
+    const pane = {
+      id: 'dmux-1', slug: 'fix-auth', branchName: undefined,
+      prompt: 'test', paneId: '%1',
+    };
+    expect(getPaneBranchName(pane)).toBe('fix-auth');
+  });
+});
+
+// ─── Test 5: Input validation ───
+
+describe('isValidBranchName', () => {
+  it('accepts valid branch names', () => {
+    expect(isValidBranchName('main')).toBe(true);
+    expect(isValidBranchName('master')).toBe(true);
+    expect(isValidBranchName('develop')).toBe(true);
+    expect(isValidBranchName('feat/fix-auth')).toBe(true);
+    expect(isValidBranchName('release/v2.0')).toBe(true);
+    expect(isValidBranchName('user_branch-name.1')).toBe(true);
+  });
+
+  it('accepts empty string (means "not set")', () => {
+    expect(isValidBranchName('')).toBe(true);
+  });
+
+  it('rejects branch names with shell metacharacters', () => {
+    expect(isValidBranchName('main; rm -rf /')).toBe(false);
+    expect(isValidBranchName('$(whoami)')).toBe(false);
+    expect(isValidBranchName('`id`')).toBe(false);
+    expect(isValidBranchName("branch'name")).toBe(false);
+    expect(isValidBranchName('branch"name')).toBe(false);
+    expect(isValidBranchName('branch name')).toBe(false);
+    expect(isValidBranchName('branch|name')).toBe(false);
+    expect(isValidBranchName('branch&name')).toBe(false);
+    expect(isValidBranchName('branch>name')).toBe(false);
+  });
+
+  it('rejects common injection patterns', () => {
+    expect(isValidBranchName('main; curl attacker.com')).toBe(false);
+    expect(isValidBranchName('$(cat /etc/passwd)')).toBe(false);
+    expect(isValidBranchName('main && echo pwned')).toBe(false);
+  });
+});
+
+// ─── Test 5: Settings validation at write time ───
+
+describe('SettingsManager validation', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('rejects invalid baseBranch values', async () => {
+    vi.mock('fs', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('fs')>();
+      return { ...actual, existsSync: vi.fn(() => false), writeFileSync: vi.fn(), mkdirSync: vi.fn() };
+    });
+
+    const { SettingsManager } = await import('../src/utils/settingsManager.js');
+    const manager = new SettingsManager('/tmp/test-project');
+
+    expect(() => manager.updateSetting('baseBranch', 'main; rm -rf /', 'global')).toThrow('Invalid baseBranch');
+    expect(() => manager.updateSetting('baseBranch', '$(whoami)', 'global')).toThrow('Invalid baseBranch');
+  });
+
+  it('rejects invalid branchPrefix values', async () => {
+    vi.mock('fs', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('fs')>();
+      return { ...actual, existsSync: vi.fn(() => false), writeFileSync: vi.fn(), mkdirSync: vi.fn() };
+    });
+
+    const { SettingsManager } = await import('../src/utils/settingsManager.js');
+    const manager = new SettingsManager('/tmp/test-project');
+
+    expect(() => manager.updateSetting('branchPrefix', '`id`/', 'global')).toThrow('Invalid branchPrefix');
+    expect(() => manager.updateSetting('branchPrefix', 'feat && echo pwned/', 'project')).toThrow('Invalid branchPrefix');
+  });
+
+  it('accepts valid baseBranch and branchPrefix values', async () => {
+    vi.mock('fs', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('fs')>();
+      return { ...actual, existsSync: vi.fn(() => false), writeFileSync: vi.fn(), mkdirSync: vi.fn() };
+    });
+
+    const { SettingsManager } = await import('../src/utils/settingsManager.js');
+    const manager = new SettingsManager('/tmp/test-project');
+
+    expect(() => manager.updateSetting('baseBranch', 'main', 'global')).not.toThrow();
+    expect(() => manager.updateSetting('baseBranch', 'develop', 'global')).not.toThrow();
+    expect(() => manager.updateSetting('baseBranch', '', 'global')).not.toThrow();
+    expect(() => manager.updateSetting('branchPrefix', 'feat/', 'global')).not.toThrow();
+    expect(() => manager.updateSetting('branchPrefix', 'fix/', 'project')).not.toThrow();
+    expect(() => manager.updateSetting('branchPrefix', '', 'global')).not.toThrow();
+  });
+});
+
+// ─── Test 2: Slug vs branchName separation ───
+
+describe('slug and branchName separation', () => {
+  it('slug stays filesystem-safe, branchName includes prefix', () => {
+    const branchPrefix = 'feat/';
+    const slug = 'fix-auth';
+    const branchName = branchPrefix ? `${branchPrefix}${slug}` : slug;
+
+    expect(slug).toBe('fix-auth');
+    expect(branchName).toBe('feat/fix-auth');
+    expect(slug).not.toContain('/');
+  });
+
+  it('worktree path uses slug, not branchName', () => {
+    const projectRoot = '/home/user/project';
+    const slug = 'fix-auth';
+    const worktreePath = `${projectRoot}/.dmux/worktrees/${slug}`;
+
+    expect(worktreePath).toBe('/home/user/project/.dmux/worktrees/fix-auth');
+    expect(worktreePath.split('/').pop()).toBe('fix-auth');
+  });
+
+  it('branchName stored on pane only when different from slug', () => {
+    const slug = 'fix-auth';
+
+    // With prefix: branchName is stored
+    const withPrefix = 'feat/fix-auth' !== slug ? 'feat/fix-auth' : undefined;
+    expect(withPrefix).toBe('feat/fix-auth');
+
+    // Without prefix: branchName is not stored
+    const noPrefix = 'fix-auth' !== slug ? 'fix-auth' : undefined;
+    expect(noPrefix).toBeUndefined();
+  });
+});
+
+// ─── Test 3: Merge operations quote branch names ───
+
+describe('merge operations quote branch names', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('mergeWorktreeIntoMain quotes branch name', async () => {
+    vi.mock('child_process', () => ({
+      execSync: vi.fn().mockReturnValue(Buffer.from('')),
+    }));
+
+    const { mergeWorktreeIntoMain } = await import('../src/utils/mergeExecution.js');
+    const { execSync } = await import('child_process');
+
+    mergeWorktreeIntoMain('/test/repo', 'feat/fix-auth');
+
+    expect(execSync).toHaveBeenCalledWith(
+      'git merge "feat/fix-auth" --no-edit',
+      expect.any(Object)
+    );
+  });
+
+  it('mergeMainIntoWorktree quotes branch name', async () => {
+    vi.mock('child_process', () => ({
+      execSync: vi.fn().mockReturnValue(Buffer.from('')),
+    }));
+
+    const { mergeMainIntoWorktree } = await import('../src/utils/mergeExecution.js');
+    const { execSync } = await import('child_process');
+
+    mergeMainIntoWorktree('/test/worktree', 'main');
+
+    expect(execSync).toHaveBeenCalledWith(
+      'git merge "main" --no-edit',
+      expect.any(Object)
+    );
+  });
+
+  it('cleanupAfterMerge quotes branch name in git branch -d', async () => {
+    vi.mock('child_process', () => ({
+      execSync: vi.fn().mockReturnValue(Buffer.from('')),
+    }));
+
+    const { cleanupAfterMerge } = await import('../src/utils/mergeExecution.js');
+    const { execSync } = await import('child_process');
+
+    cleanupAfterMerge('/test/repo', '/test/worktree', 'feat/fix-auth');
+
+    expect(execSync).toHaveBeenCalledWith(
+      'git branch -d "feat/fix-auth"',
+      expect.any(Object)
+    );
+  });
+});
+
+// ─── Test 4: Orphaned worktree discovery with prefixed panes ───
+
+describe('orphaned worktree discovery with prefixed panes', () => {
+  it('directory name matches slug (not branchName), so discovery works', () => {
+    const activePanes = [
+      { slug: 'fix-auth', branchName: 'feat/fix-auth' },
+      { slug: 'add-tests', branchName: 'chore/add-tests' },
+    ];
+    const activeSlugs = activePanes.map(p => p.slug);
+    const directoryEntries = ['fix-auth', 'add-tests', 'old-orphan'];
+
+    const orphaned = directoryEntries.filter(name => !activeSlugs.includes(name));
+
+    expect(orphaned).toEqual(['old-orphan']);
+    expect(activeSlugs).toContain('fix-auth');
+    expect(activeSlugs).toContain('add-tests');
+  });
+
+  it('prefixed branchName would NOT match directory entries (proving slug is needed)', () => {
+    const activeBranchNames = ['feat/fix-auth', 'chore/add-tests'];
+    const directoryEntries = ['fix-auth', 'add-tests'];
+
+    const matched = directoryEntries.filter(name => activeBranchNames.includes(name));
+    expect(matched).toHaveLength(0); // None match — everything wrongly "orphaned"
+  });
+});
+
+// ─── Test 6: Nonexistent baseBranch error ───
+
+describe('nonexistent baseBranch validation', () => {
+  it('error message is clear and actionable', () => {
+    // Simulates the error thrown in paneCreation.ts when baseBranch doesn't exist
+    const baseBranch = 'nonexistent-branch';
+    const errorMessage = `Base branch "${baseBranch}" does not exist. Update the baseBranch setting to a valid branch name.`;
+
+    expect(errorMessage).toContain('nonexistent-branch');
+    expect(errorMessage).toContain('does not exist');
+    expect(errorMessage).toContain('Update the baseBranch setting');
+  });
+});
+
+// ─── Test 1: baseBranch in git worktree add command ───
+
+describe('baseBranch in worktree creation command', () => {
+  it('produces correct command with baseBranch as start-point', () => {
+    const worktreePath = '/project/.dmux/worktrees/fix-auth';
+    const branchName = 'feat/fix-auth';
+    const baseBranch = 'main';
+
+    const startPoint = baseBranch ? ` "${baseBranch}"` : '';
+    const cmd = `git worktree add "${worktreePath}" -b "${branchName}"${startPoint}`;
+
+    expect(cmd).toBe('git worktree add "/project/.dmux/worktrees/fix-auth" -b "feat/fix-auth" "main"');
+  });
+
+  it('produces correct command without baseBranch (uses HEAD)', () => {
+    const worktreePath = '/project/.dmux/worktrees/fix-auth';
+    const branchName = 'fix-auth';
+    const baseBranch = '';
+
+    const startPoint = baseBranch ? ` "${baseBranch}"` : '';
+    const cmd = `git worktree add "${worktreePath}" -b "${branchName}"${startPoint}`;
+
+    expect(cmd).toBe('git worktree add "/project/.dmux/worktrees/fix-auth" -b "fix-auth"');
+  });
+
+  it('uses existing branch without -b flag when branch exists', () => {
+    const worktreePath = '/project/.dmux/worktrees/fix-auth';
+    const branchName = 'feat/fix-auth';
+
+    const cmd = `git worktree add "${worktreePath}" "${branchName}"`;
+
+    expect(cmd).toBe('git worktree add "/project/.dmux/worktrees/fix-auth" "feat/fix-auth"');
+  });
+});
+
+// ─── DMUX_BRANCH hook env ───
+
+describe('hooks environment uses branchName', () => {
+  it('uses branchName when set', () => {
+    const pane = { slug: 'fix-auth', branchName: 'feat/fix-auth', worktreePath: '/x' };
+    expect(pane.branchName || pane.slug).toBe('feat/fix-auth');
+  });
+
+  it('falls back to slug when no branchName', () => {
+    const pane: { slug: string; branchName?: string } = { slug: 'fix-auth' };
+    expect(pane.branchName || pane.slug).toBe('fix-auth');
+  });
+});
+
+// ─── Setting definitions ───
+
+describe('setting definitions', () => {
+  it('baseBranch has correct options', async () => {
+    const { SETTING_DEFINITIONS } = await import('../src/utils/settingsManager.js');
+    const def = SETTING_DEFINITIONS.find(d => d.key === 'baseBranch');
+
+    expect(def).toBeDefined();
+    expect(def!.type).toBe('select');
+
+    const values = def!.options!.map(o => o.value);
+    expect(values).toContain('');
+    expect(values).toContain('main');
+    expect(values).toContain('master');
+    expect(values).toContain('develop');
+  });
+
+  it('branchPrefix has common prefix options', async () => {
+    const { SETTING_DEFINITIONS } = await import('../src/utils/settingsManager.js');
+    const def = SETTING_DEFINITIONS.find(d => d.key === 'branchPrefix');
+
+    expect(def).toBeDefined();
+    expect(def!.type).toBe('select');
+
+    const values = def!.options!.map(o => o.value);
+    expect(values).toContain('');
+    expect(values).toContain('feat/');
+    expect(values).toContain('fix/');
+    expect(values).toContain('chore/');
+  });
+});

--- a/__tests__/integration/gitOperations.test.ts
+++ b/__tests__/integration/gitOperations.test.ts
@@ -321,7 +321,7 @@ describe('Git Operations Integration Tests', () => {
 
       expect(result.success).toBe(true);
       expect(mockExecSync).toHaveBeenCalledWith(
-        expect.stringContaining('git merge main'),
+        expect.stringContaining('git merge "main"'),
         expect.any(Object)
       );
     });
@@ -333,7 +333,7 @@ describe('Git Operations Integration Tests', () => {
 
       expect(result.success).toBe(true);
       expect(mockExecSync).toHaveBeenCalledWith(
-        expect.stringContaining('git merge feature-branch'),
+        expect.stringContaining('git merge "feature-branch"'),
         expect.any(Object)
       );
     });

--- a/src/actions/implementations/closeAction.ts
+++ b/src/actions/implementations/closeAction.ts
@@ -13,6 +13,7 @@ import { triggerHook } from '../../utils/hooks.js';
 import { LogService } from '../../services/LogService.js';
 import { TMUX_SPLIT_DELAY } from '../../constants/timing.js';
 import { deriveProjectRootFromWorktreePath, getPaneProjectRoot } from '../../utils/paneProject.js';
+import { getPaneBranchName } from '../../utils/git.js';
 
 /**
  * Close a pane - presents options for how to close
@@ -179,7 +180,7 @@ async function executeCloseOption(
         // Delete branch if requested
         if (option === 'kill_clean_branch') {
           try {
-            execSync(`git branch -D ${pane.slug}`, {
+            execSync(`git branch -D "${getPaneBranchName(pane)}"`, {
               stdio: 'pipe',
               cwd: mainRepoPath,
             });

--- a/src/actions/implementations/mergeAction.ts
+++ b/src/actions/implementations/mergeAction.ts
@@ -8,6 +8,7 @@
 import type { DmuxPane } from '../../types.js';
 import type { ActionResult, ActionContext } from '../types.js';
 import { triggerHook } from '../../utils/hooks.js';
+import { getPaneBranchName } from '../../utils/git.js';
 import { executeMerge } from '../merge/mergeExecution.js';
 import {
   handleNothingToMerge,
@@ -80,7 +81,7 @@ async function executeSingleRootMerge(
 ): Promise<ActionResult> {
   const { validateMerge } = await import('../../utils/mergeValidation.js');
   const mainRepoPath = pane.worktreePath!.replace(/\/\.dmux\/worktrees\/[^/]+$/, '');
-  const validation = validateMerge(mainRepoPath, pane.worktreePath!, pane.slug);
+  const validation = validateMerge(mainRepoPath, pane.worktreePath!, getPaneBranchName(pane));
 
   // Handle detected issues
   if (!validation.canMerge) {

--- a/src/actions/merge/conflictResolution.ts
+++ b/src/actions/merge/conflictResolution.ts
@@ -8,6 +8,7 @@
 import type { ActionResult, ActionContext } from '../types.js';
 import type { DmuxPane } from '../../types.js';
 import { TmuxService } from '../../services/TmuxService.js';
+import { getPaneBranchName } from '../../utils/git.js';
 
 /**
  * Create a new pane for AI-assisted conflict resolution
@@ -86,7 +87,7 @@ async function createAndLaunchConflictPane(
     // NOTE: We pass the WORKTREE path as targetRepoPath because that's where
     // the conflicts exist and need to be resolved (not in main repo)
     const conflictPane = await createConflictResolutionPane({
-      sourceBranch: pane.slug,
+      sourceBranch: getPaneBranchName(pane),
       targetBranch,
       targetRepoPath: pane.worktreePath!, // CRITICAL: Use worktree, not main repo
       agent,

--- a/src/actions/merge/mergeExecution.ts
+++ b/src/actions/merge/mergeExecution.ts
@@ -8,6 +8,7 @@
 import type { ActionResult, ActionContext } from "../types.js"
 import type { DmuxPane } from "../../types.js"
 import { triggerHook } from "../../utils/hooks.js"
+import { getPaneBranchName } from "../../utils/git.js"
 
 /**
  * Execute merge with conflict handling
@@ -206,7 +207,7 @@ export async function executeMerge(
   }
 
   // Step 2: Merge worktree into main (bring changes back to main)
-  const step2 = mergeWorktreeIntoMain(mainRepoPath, pane.slug)
+  const step2 = mergeWorktreeIntoMain(mainRepoPath, getPaneBranchName(pane))
 
   if (!step2.success) {
     return {

--- a/src/components/panes/MergePane.tsx
+++ b/src/components/panes/MergePane.tsx
@@ -8,6 +8,7 @@ interface MergePaneProps {
   pane: {
     id: string;
     slug: string;
+    branchName?: string;
     prompt: string;
     paneId: string;
     worktreePath?: string;
@@ -173,7 +174,8 @@ export default function MergePane({ pane, onComplete, onCancel, mainBranch }: Me
 
     // Step 4: Attempt merge in the main repository
     setStatus('merging');
-    const mergeResult = runCommand(`git merge ${pane.slug} --no-ff`, mainRepoPath);
+    const mergeBranch = pane.branchName || pane.slug;
+    const mergeResult = runCommand(`git merge "${mergeBranch}" --no-ff`, mainRepoPath);
 
     if (!mergeResult.success) {
       // Check if it's a merge conflict

--- a/src/hooks/useWorktreeActions.ts
+++ b/src/hooks/useWorktreeActions.ts
@@ -5,7 +5,7 @@ import type { DmuxPane } from '../types.js';
 import { TmuxService } from '../services/TmuxService.js';
 import { enforceControlPaneSize } from '../utils/tmux.js';
 import { SIDEBAR_WIDTH } from '../utils/layoutManager.js';
-import { getCurrentBranch } from '../utils/git.js';
+import { getCurrentBranch, getPaneBranchName } from '../utils/git.js';
 import { useTemporaryStatus } from './useTemporaryStatus.js';
 
 interface Params {
@@ -68,12 +68,12 @@ export default function useWorktreeActions({ panes, savePanes, setStatusMessage,
 
       setStatusMessage('Merging into main...');
       try {
-        execSync(`git merge ${pane.slug}`, { stdio: 'pipe' });
+        execSync(`git merge "${getPaneBranchName(pane)}"`, { stdio: 'pipe' });
       } catch (mergeError: any) {
         const errorMessage = mergeError.message || String(mergeError);
         if (errorMessage.includes('CONFLICT') || errorMessage.includes('conflict')) {
           process.stderr.write('\n\x1b[31m✗ Merge conflict detected!\x1b[0m\n');
-          process.stderr.write(`\nThere are merge conflicts when merging branch '${pane.slug}' into '${mainBranch}'.\n`);
+          process.stderr.write(`\nThere are merge conflicts when merging branch '${getPaneBranchName(pane)}' into '${mainBranch}'.\n`);
           process.stderr.write('\nTo resolve:\n');
           process.stderr.write('1. Manually resolve the merge conflicts in your editor\n');
           process.stderr.write('2. Stage the resolved files: git add <resolved-files>\n');
@@ -94,7 +94,7 @@ export default function useWorktreeActions({ panes, savePanes, setStatusMessage,
 
       // Only remove worktree if merge succeeded
       execSync(`git worktree remove "${pane.worktreePath}"`, { stdio: 'pipe' });
-      execSync(`git branch -d ${pane.slug}`, { stdio: 'pipe' });
+      execSync(`git branch -d "${getPaneBranchName(pane)}"`, { stdio: 'pipe' });
 
       setStatusMessage(`Merged ${pane.slug} into ${mainBranch}`);
       setTimeout(() => setStatusMessage(''), 3000);
@@ -127,12 +127,12 @@ export default function useWorktreeActions({ panes, savePanes, setStatusMessage,
 
       setStatusMessage('Merging into main...');
       try {
-        execSync(`git merge ${pane.slug}`, { stdio: 'pipe' });
+        execSync(`git merge "${getPaneBranchName(pane)}"`, { stdio: 'pipe' });
       } catch (mergeError: any) {
         const errorMessage = mergeError.message || String(mergeError);
         if (errorMessage.includes('CONFLICT') || errorMessage.includes('conflict')) {
           process.stderr.write('\n\x1b[31m✗ Merge conflict detected!\x1b[0m\n');
-          process.stderr.write(`\nThere are merge conflicts when merging branch '${pane.slug}' into '${mainBranch}'.\n`);
+          process.stderr.write(`\nThere are merge conflicts when merging branch '${getPaneBranchName(pane)}' into '${mainBranch}'.\n`);
           process.stderr.write('\nTo resolve:\n');
           process.stderr.write('1. Manually resolve the merge conflicts in your editor\n');
           process.stderr.write('2. Stage the resolved files: git add <resolved-files>\n');
@@ -153,7 +153,7 @@ export default function useWorktreeActions({ panes, savePanes, setStatusMessage,
 
       // Only remove worktree if merge succeeded
       execSync(`git worktree remove "${pane.worktreePath}"`, { stdio: 'pipe' });
-      execSync(`git branch -d ${pane.slug}`, { stdio: 'pipe' });
+      execSync(`git branch -d "${getPaneBranchName(pane)}"`, { stdio: 'pipe' });
       await closePane(pane);
       setStatusMessage(`Merged ${pane.slug} into ${mainBranch} and closed pane`);
       setTimeout(() => setStatusMessage(''), 3000);
@@ -172,7 +172,7 @@ export default function useWorktreeActions({ panes, savePanes, setStatusMessage,
     try {
       setStatusMessage('Removing worktree with unsaved changes...');
       execSync(`git worktree remove --force "${pane.worktreePath}"`, { stdio: 'pipe' });
-      try { execSync(`git branch -D ${pane.slug}`, { stdio: 'pipe' }); } catch {}
+      try { execSync(`git branch -D "${getPaneBranchName(pane)}"`, { stdio: 'pipe' }); } catch {}
       await closePane(pane);
       setStatusMessage(`Deleted worktree ${pane.slug} and closed pane`);
       setTimeout(() => setStatusMessage(''), 3000);

--- a/src/server/routes/settingsRoutes.ts
+++ b/src/server/routes/settingsRoutes.ts
@@ -73,11 +73,12 @@ export function createSettingsRoutes() {
               message: `Setting "${key}" updated at ${scope} level`
             };
           } catch (err: any) {
-            const msg = 'Failed to update setting';
+            const msg = err.message || 'Failed to update setting';
             console.error(msg, err);
             LogService.getInstance().error(msg, 'routes', undefined, err instanceof Error ? err : undefined);
-            event.node.res.statusCode = 500;
-            return { error: 'Failed to update setting', details: err.message };
+            // Return 400 for validation errors, 500 for unexpected errors
+            event.node.res.statusCode = msg.includes('Invalid') ? 400 : 500;
+            return { error: msg };
           }
         }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,7 @@ export interface PotentialHarm {
 export interface DmuxPane {
   id: string;
   slug: string;
+  branchName?: string; // Git branch name (may differ from slug when branchPrefix is set)
   prompt: string;
   paneId: string;
   projectRoot?: string; // Main repository root this pane belongs to
@@ -73,6 +74,11 @@ export interface DmuxSettings {
   // Tmux hooks for event-driven updates (low CPU)
   // true = use hooks, false = use polling, undefined = not yet asked
   useTmuxHooks?: boolean;
+  // Base branch for new worktrees (e.g. 'main', 'master', 'develop')
+  // When set, worktrees branch from this instead of the current HEAD
+  baseBranch?: string;
+  // Prefix for branch names (e.g. 'feat/' produces 'feat/fix-auth')
+  branchPrefix?: string;
 }
 
 export type SettingsScope = 'global' | 'project';

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -3,6 +3,27 @@ import * as fs from 'fs';
 import * as fsPromises from 'fs/promises';
 import * as path from 'path';
 import { execAsync, execAsyncRace } from './execAsync.js';
+import type { DmuxPane } from '../types.js';
+
+/** Regex for characters allowed in git branch names and branch prefixes */
+export const SAFE_BRANCH_CHARS = /^[a-zA-Z0-9._\/-]*$/;
+
+/**
+ * Get the git branch name for a pane.
+ * Returns branchName if set (prefix-based), otherwise falls back to slug.
+ */
+export function getPaneBranchName(pane: DmuxPane): string {
+  return pane.branchName || pane.slug;
+}
+
+/**
+ * Validate that a string is safe for use as a git branch name or prefix.
+ * Returns true if valid, false if it contains dangerous characters.
+ */
+export function isValidBranchName(name: string): boolean {
+  if (!name) return true; // empty is valid (means "not set")
+  return SAFE_BRANCH_CHARS.test(name);
+}
 
 /**
  * Detects the main/master branch name for the repository (async version)

--- a/src/utils/hooks.ts
+++ b/src/utils/hooks.ts
@@ -116,7 +116,7 @@ export async function buildHookEnvironment(
 
     if (pane.worktreePath) {
       env.DMUX_WORKTREE_PATH = pane.worktreePath;
-      env.DMUX_BRANCH = pane.slug; // Branch name matches slug
+      env.DMUX_BRANCH = pane.branchName || pane.slug; // Branch name (may differ from slug with prefix)
     }
   }
 

--- a/src/utils/mergeExecution.ts
+++ b/src/utils/mergeExecution.ts
@@ -22,7 +22,7 @@ export function mergeMainIntoWorktree(
   mainBranch: string
 ): MergeResult {
   try {
-    execSync(`git merge ${mainBranch} --no-edit`, {
+    execSync(`git merge "${mainBranch}" --no-edit`, {
       cwd: worktreePath,
       stdio: 'pipe',
     });
@@ -69,7 +69,7 @@ export function mergeWorktreeIntoMain(
   worktreeBranch: string
 ): MergeResult {
   try {
-    execSync(`git merge ${worktreeBranch} --no-edit`, {
+    execSync(`git merge "${worktreeBranch}" --no-edit`, {
       cwd: mainRepoPath,
       stdio: 'pipe',
     });
@@ -201,7 +201,7 @@ export function cleanupAfterMerge(
     });
 
     // Delete branch (use -d for safety, it will fail if not merged)
-    execSync(`git branch -d ${branchName}`, {
+    execSync(`git branch -d "${branchName}"`, {
       cwd: mainRepoPath,
       stdio: 'pipe',
     });


### PR DESCRIPTION
## Summary
- Add `baseBranch` setting to create worktrees from a specific branch (e.g. main, develop) instead of current HEAD
- Add `branchPrefix` setting to prepend a prefix to branch names (e.g. `feat/fix-auth`)
- Separate `branchName` from `slug` on `DmuxPane` so filesystem paths stay flat while git branches can contain `/`
- Validate and quote all branch-related values in shell commands to prevent injection
- Verify `baseBranch` exists with `git rev-parse` before worktree creation
- Add 26 tests covering all new behavior

## Test plan
- [x] Set `baseBranch` to `main` in settings, verify new worktrees branch from main regardless of current checkout
- [x] Set `branchPrefix` to `feat/`, verify branch is `feat/<slug>` but worktree dir is just `<slug>`
- [x] Verify merge and close operations work correctly with prefixed branches
- [x] Verify orphaned worktree discovery still works with prefixed panes
- [x] Verify settings API rejects invalid characters in baseBranch/branchPrefix
- [x] Verify setting a nonexistent baseBranch shows clear error