### PR TITLE
feat: add project select popup with directory browser and autocomplete

### DIFF
--- a/src/components/popups/projectSelectPopup.tsx
+++ b/src/components/popups/projectSelectPopup.tsx
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+
+/**
+ * Standalone popup for selecting a project directory with autocomplete.
+ * Runs in a tmux popup modal and writes result to a file.
+ */
+
+import React, { useState, useEffect } from "react"
+import { render, Box, Text, useApp, useInput } from "ink"
+import * as fs from "fs"
+import CleanTextInput from "../inputs/CleanTextInput.js"
+import {
+  PopupContainer,
+  PopupInputBox,
+  PopupWrapper,
+  DirectoryList,
+  writeSuccessAndExit,
+} from "./shared/index.js"
+import { POPUP_CONFIG } from "./config.js"
+import {
+  expandTilde,
+  parsePathInput,
+  scanDirectories,
+  type DirEntry,
+} from "../../utils/dirScanner.js"
+
+interface ProjectSelectProps {
+  resultFile: string
+  defaultValue: string
+}
+
+const ProjectSelectApp: React.FC<ProjectSelectProps> = ({
+  resultFile,
+  defaultValue,
+}) => {
+  const [value, setValue] = useState(defaultValue)
+  const [directories, setDirectories] = useState<DirEntry[]>([])
+  const [selectedDirIndex, setSelectedDirIndex] = useState(0)
+  const { exit } = useApp()
+
+  // Scan directories on every input change
+  useEffect(() => {
+    const { parentDir, prefix } = parsePathInput(value)
+    const results = scanDirectories(parentDir, prefix)
+    setDirectories(results)
+    setSelectedDirIndex(0)
+  }, [value])
+
+  // Handle keyboard navigation
+  useInput((input, key) => {
+    // ESC progressive: first clear input, then let PopupWrapper close
+    if (key.escape) {
+      if (value.length > 0) {
+        setValue("")
+        return
+      }
+      // Let PopupWrapper handle close
+      return
+    }
+
+    // Arrow up/down — navigate directory list
+    if (key.upArrow) {
+      setSelectedDirIndex((prev) => Math.max(0, prev - 1))
+      return
+    }
+    if (key.downArrow) {
+      setSelectedDirIndex((prev) =>
+        Math.min(directories.length - 1, prev + 1)
+      )
+      return
+    }
+
+    // Tab — complete selected directory
+    if (key.tab && directories.length > 0) {
+      const selected = directories[selectedDirIndex]
+      if (selected) {
+        setValue(selected.fullPath + "/")
+      }
+      return
+    }
+  })
+
+  const handleSubmit = (submittedValue?: string) => {
+    const finalValue = submittedValue || value
+    if (!finalValue.trim()) return
+    // Expand tilde before submitting
+    const expanded = expandTilde(finalValue)
+    writeSuccessAndExit(resultFile, expanded, exit)
+  }
+
+  const shouldAllowCancel = () => {
+    // Block cancel if there's text in the input
+    if (value.length > 0) return false
+    return true
+  }
+
+  const footer = `Tab complete • Enter submit • ${POPUP_CONFIG.cancelHint}`
+
+  return (
+    <PopupWrapper
+      resultFile={resultFile}
+      allowEscapeToCancel={true}
+      shouldAllowCancel={shouldAllowCancel}
+    >
+      <PopupContainer footer={footer}>
+        {/* Instructions */}
+        <Box marginBottom={1} flexDirection="column">
+          <Text dimColor>
+            Enter a repository path (repo root or any subdirectory)
+          </Text>
+        </Box>
+
+        {/* Input area with themed border */}
+        <Box
+          width="100%"
+          borderStyle={POPUP_CONFIG.inputBorderStyle}
+          borderColor={POPUP_CONFIG.inputBorderColor}
+          paddingX={POPUP_CONFIG.inputPadding.x}
+          paddingY={POPUP_CONFIG.inputPadding.y}
+        >
+          <CleanTextInput
+            value={value}
+            onChange={setValue}
+            onSubmit={handleSubmit}
+            placeholder="~/projects/my-app"
+            maxWidth={72}
+            disableUpDownArrows={true}
+            disableEscape={true}
+            ignoreFocus={true}
+          />
+        </Box>
+
+        {/* Directory suggestions (always shown) */}
+        <DirectoryList
+          directories={directories}
+          selectedIndex={selectedDirIndex}
+          maxVisible={8}
+        />
+      </PopupContainer>
+    </PopupWrapper>
+  )
+}
+
+// Entry point
+function main() {
+  const resultFile = process.argv[2]
+  const dataFile = process.argv[3]
+
+  if (!resultFile) {
+    console.error("Error: Result file path required")
+    process.exit(1)
+  }
+
+  let defaultValue = ""
+  if (dataFile) {
+    try {
+      const dataJson = fs.readFileSync(dataFile, "utf-8")
+      const data = JSON.parse(dataJson)
+      defaultValue = data.defaultValue || ""
+    } catch {
+      // Ignore parse errors — use empty default
+    }
+  }
+
+  render(
+    <ProjectSelectApp resultFile={resultFile} defaultValue={defaultValue} />
+  )
+}
+
+main()

--- a/src/components/popups/shared/DirectoryList.tsx
+++ b/src/components/popups/shared/DirectoryList.tsx
@@ -1,0 +1,115 @@
+import React from "react"
+import { Box, Text } from "ink"
+import { POPUP_CONFIG } from "../config.js"
+import type { DirEntry } from "../../../utils/dirScanner.js"
+
+interface DirectoryListProps {
+  directories: DirEntry[]
+  selectedIndex: number
+  maxVisible?: number
+}
+
+/**
+ * Displays a scrollable list of directories with git repo indicators.
+ * Used for directory autocomplete in the project select popup.
+ */
+export const DirectoryList: React.FC<DirectoryListProps> = ({
+  directories,
+  selectedIndex,
+  maxVisible = 10,
+}) => {
+  if (directories.length === 0) {
+    return (
+      <Box marginTop={1}>
+        <Text dimColor italic>
+          No directories found
+        </Text>
+      </Box>
+    )
+  }
+
+  // Calculate visible window (scrolling)
+  const totalDirs = directories.length
+  let startIndex = 0
+  let endIndex = Math.min(maxVisible, totalDirs)
+
+  // Keep selected item centered when possible
+  if (selectedIndex >= maxVisible / 2 && totalDirs > maxVisible) {
+    startIndex = Math.max(0, selectedIndex - Math.floor(maxVisible / 2))
+    endIndex = Math.min(startIndex + maxVisible, totalDirs)
+    startIndex = endIndex - maxVisible
+  } else if (selectedIndex >= endIndex) {
+    endIndex = selectedIndex + 1
+    startIndex = Math.max(0, endIndex - maxVisible)
+  }
+
+  const visibleDirs = directories.slice(startIndex, endIndex)
+  const showScrollIndicators = totalDirs > maxVisible
+
+  return (
+    <Box
+      flexDirection="column"
+      marginTop={1}
+      borderStyle={POPUP_CONFIG.inputBorderStyle}
+      borderColor="cyan"
+      paddingX={1}
+      width="100%"
+    >
+      {/* Header */}
+      <Box marginBottom={0}>
+        <Text dimColor>
+          Directories ({totalDirs}) — ↑↓ navigate, Tab complete
+        </Text>
+      </Box>
+
+      {/* Scroll indicator - top */}
+      {showScrollIndicators && startIndex > 0 && (
+        <Box justifyContent="center">
+          <Text dimColor>↑ {startIndex} more above</Text>
+        </Box>
+      )}
+
+      {/* Directory list */}
+      <Box flexDirection="column">
+        {visibleDirs.map((dir, idx) => {
+          const actualIndex = startIndex + idx
+          const isSelected = actualIndex === selectedIndex
+
+          return (
+            <Box key={actualIndex} flexDirection="column">
+              <Box>
+                <Text
+                  color={isSelected ? "black" : undefined}
+                  backgroundColor={isSelected ? "cyan" : undefined}
+                  bold={isSelected}
+                >
+                  {isSelected ? "▶ " : "  "}
+                  {dir.name}/
+                </Text>
+                {dir.isGitRepo && (
+                  <Text color="cyan" bold={isSelected}>
+                    {" "}
+                    [git]
+                  </Text>
+                )}
+              </Box>
+              <Box>
+                <Text dimColor>
+                  {"    "}
+                  {dir.fullPath}
+                </Text>
+              </Box>
+            </Box>
+          )
+        })}
+      </Box>
+
+      {/* Scroll indicator - bottom */}
+      {showScrollIndicators && endIndex < totalDirs && (
+        <Box justifyContent="center">
+          <Text dimColor>↓ {totalDirs - endIndex} more below</Text>
+        </Box>
+      )}
+    </Box>
+  )
+}

--- a/src/components/popups/shared/index.ts
+++ b/src/components/popups/shared/index.ts
@@ -5,6 +5,7 @@
 export { PopupContainer } from './PopupContainer.js';
 export { PopupInputBox } from './PopupInputBox.js';
 export { FileList } from './FileList.js';
+export { DirectoryList } from './DirectoryList.js';
 export {
   PopupWrapper,
   writeSuccessAndExit,

--- a/src/hooks/useInputHandling.ts
+++ b/src/hooks/useInputHandling.ts
@@ -172,10 +172,7 @@ export function useInputHandling(params: UseInputHandlingParams) {
       ? getPaneProjectRoot(selectedPane, projectRoot)
       : (selectedAction?.projectRoot || projectRoot)
 
-    const requestedProjectPath = await popupManager.launchInputPopup(
-      "Select Project",
-      "Enter a repository path (repo root or any subdirectory)",
-      "~/projects/my-app",
+    const requestedProjectPath = await popupManager.launchProjectSelectPopup(
       defaultProjectPath
     )
 

--- a/src/services/PopupManager.ts
+++ b/src/services/PopupManager.ts
@@ -494,6 +494,32 @@ export class PopupManager {
     }
   }
 
+  async launchProjectSelectPopup(
+    defaultValue?: string
+  ): Promise<string | null> {
+    if (!this.checkPopupSupport()) return null
+
+    try {
+      const result = await this.launchPopup<string>(
+        "projectSelectPopup.js",
+        [],
+        {
+          width: 80,
+          height: 25,
+          title: "  Select Project  ",
+          positioning: "centered",
+        },
+        { defaultValue: defaultValue || "" }
+      )
+
+      this.ignoreInputBriefly()
+      return this.handleResult(result)
+    } catch (error: any) {
+      this.showTempMessage(`Failed to launch popup: ${error.message}`)
+      return null
+    }
+  }
+
   async launchInputPopup(
     title: string,
     message: string,

--- a/src/utils/dirScanner.ts
+++ b/src/utils/dirScanner.ts
@@ -1,0 +1,124 @@
+import fs from "fs"
+import path from "path"
+import os from "os"
+
+export interface DirEntry {
+  name: string
+  fullPath: string
+  isGitRepo: boolean
+}
+
+interface CacheEntry {
+  entries: DirEntry[]
+  timestamp: number
+}
+
+const CACHE_TTL_MS = 500
+const MAX_ENTRIES = 50
+const dirCache = new Map<string, CacheEntry>()
+
+/**
+ * Expand ~ to the user's home directory
+ */
+export function expandTilde(inputPath: string): string {
+  if (inputPath === "~") return os.homedir()
+  if (inputPath.startsWith("~/")) {
+    return path.join(os.homedir(), inputPath.slice(2))
+  }
+  return inputPath
+}
+
+/**
+ * Split user input into parentDir + prefix for filtering.
+ *
+ * Examples:
+ *   "~/pro"        → { parentDir: "/Users/x", prefix: "pro" }
+ *   "~/projects/"  → { parentDir: "/Users/x/projects", prefix: "" }
+ *   "/tmp"         → { parentDir: "/", prefix: "tmp" }
+ *   "/tmp/"        → { parentDir: "/tmp", prefix: "" }
+ *   ""             → { parentDir: homedir, prefix: "" }
+ */
+export function parsePathInput(input: string): {
+  parentDir: string
+  prefix: string
+} {
+  if (!input) {
+    return { parentDir: os.homedir(), prefix: "" }
+  }
+
+  const expanded = expandTilde(input)
+
+  // If it ends with /, the parent is the full path, prefix is empty
+  if (expanded.endsWith("/")) {
+    return { parentDir: expanded.slice(0, -1) || "/", prefix: "" }
+  }
+
+  return {
+    parentDir: path.dirname(expanded),
+    prefix: path.basename(expanded),
+  }
+}
+
+/**
+ * Scan a directory for subdirectories, optionally filtering by prefix.
+ * Results are cached by parentDir for 500ms.
+ * Returns max 50 entries, sorted: git repos first, then alphabetical.
+ */
+export function scanDirectories(
+  parentDir: string,
+  prefix: string
+): DirEntry[] {
+  // Check cache
+  const cached = dirCache.get(parentDir)
+  const now = Date.now()
+  let allEntries: DirEntry[]
+
+  if (cached && now - cached.timestamp < CACHE_TTL_MS) {
+    allEntries = cached.entries
+  } else {
+    allEntries = readDirectoryEntries(parentDir)
+    dirCache.set(parentDir, { entries: allEntries, timestamp: now })
+  }
+
+  // Filter by prefix (case-insensitive)
+  const lowerPrefix = prefix.toLowerCase()
+  const filtered = lowerPrefix
+    ? allEntries.filter((e) => e.name.toLowerCase().startsWith(lowerPrefix))
+    : allEntries
+
+  // Sort: git repos first, then alphabetical
+  filtered.sort((a, b) => {
+    if (a.isGitRepo !== b.isGitRepo) return a.isGitRepo ? -1 : 1
+    return a.name.localeCompare(b.name)
+  })
+
+  return filtered.slice(0, MAX_ENTRIES)
+}
+
+function readDirectoryEntries(parentDir: string): DirEntry[] {
+  try {
+    const entries = fs.readdirSync(parentDir, { withFileTypes: true })
+    const dirs: DirEntry[] = []
+
+    for (const entry of entries) {
+      // Skip hidden dirs unless we explicitly want them (handled by prefix filter)
+      if (entry.name.startsWith(".")) continue
+      if (!entry.isDirectory()) continue
+
+      const fullPath = path.join(parentDir, entry.name)
+      let isGitRepo = false
+      try {
+        isGitRepo = fs.existsSync(path.join(fullPath, ".git"))
+      } catch {
+        // Permission denied or similar — skip git check
+      }
+
+      dirs.push({ name: entry.name, fullPath, isGitRepo })
+    }
+
+    return dirs
+  } catch {
+    // Directory doesn't exist or permission denied
+    return []
+  }
+}


### PR DESCRIPTION
## Summary

Replaces the plain text input popup for project selection with a dedicated directory browser popup featuring real-time autocomplete, keyboard navigation, and git repo detection.

- **Directory browser popup** — new `projectSelectPopup.tsx` that scans the filesystem as you type, showing matching subdirectories with live filtering
- **Git repo indicators** — directories containing `.git` are tagged with `[git]` and sorted to the top, making it easy to find repos
- **Tab completion** — press Tab to complete the selected directory path, then keep drilling deeper
- **Scrollable list** — `DirectoryList` component with scroll indicators and centered selection, capped at 50 entries
- **Performance** — `dirScanner.ts` utility with 500ms directory cache to avoid redundant filesystem reads on every keystroke
- **Progressive ESC** — first ESC clears input, second ESC closes the popup (consistent with other dmux popups)

## Motivation

The previous project selection used a generic text input popup (`launchInputPopup`) with no filesystem awareness — users had to type full paths from memory. This is especially painful for navigating deep directory trees or remembering exact repo locations. The new popup gives immediate visual feedback about what directories exist and which ones are git repos.

## Changes

| File | What changed |
|------|-------------|
| `src/components/popups/projectSelectPopup.tsx` | New standalone popup with directory browsing UI |
| `src/components/popups/shared/DirectoryList.tsx` | Reusable scrollable directory list component |
| `src/components/popups/shared/index.ts` | Export `DirectoryList` |
| `src/utils/dirScanner.ts` | Filesystem scanning utility (tilde expansion, path parsing, cached directory reads) |
| `src/services/PopupManager.ts` | New `launchProjectSelectPopup()` method |
| `src/hooks/useInputHandling.ts` | Switch project selection to use the new popup |

## Test plan

- [ ] Open dmux, trigger project selection (new pane in different project)
- [ ] Type `~/` and verify home directory contents appear
- [ ] Type partial path (e.g., `~/pro`) and verify prefix filtering works
- [ ] Verify git repos show `[git]` tag and sort to top
- [ ] Use arrow keys to navigate the list, Tab to complete
- [ ] Press ESC with text entered — should clear input, not close popup
- [ ] Press ESC with empty input — should close popup
- [ ] Test with directories that have many subdirectories (scrolling)
- [ ] Test with non-existent paths (should show "No directories found")