### PR TITLE
Configurable agent permission mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -246,6 +246,7 @@ dmux supports both global and project-specific settings stored in:
 
 - `enableAutopilotByDefault` (boolean): Automatically enable autopilot mode for new panes
 - `defaultAgent` ('claude' | 'opencode' | ''): Default agent for new panes (empty string means "ask each time")
+- `permissionMode` ('' | 'acceptEdits' | 'plan' | 'bypassPermissions'): Agent permission level (empty = agent default/ask for permissions, dmux defaults to 'acceptEdits')
 
 **Accessing Settings:**
 
@@ -257,7 +258,7 @@ dmux supports both global and project-specific settings stored in:
 
 ### 6. Pane Lifecycle
 
-**Creation**: Generate slug → create worktree → split tmux pane → launch agent with `--permission-mode=acceptEdits`
+**Creation**: Generate slug → create worktree → split tmux pane → launch agent with configured `permissionMode` flags (default: `acceptEdits`)
 **Auto-Cleanup**: Polls every 2s, removes dead panes from tracking
 **Merge**: AI-generated commit → merge to main → remove worktree → optional pane close
 

--- a/__tests__/agentLaunch.test.ts
+++ b/__tests__/agentLaunch.test.ts
@@ -3,6 +3,7 @@ import {
   appendSlugSuffix,
   buildAgentLaunchOptions,
   getAgentSlugSuffix,
+  getPermissionFlags,
 } from '../src/utils/agentLaunch.js';
 
 describe('agent launch utils', () => {
@@ -37,5 +38,55 @@ describe('agent launch utils', () => {
       'claude+codex',
       'opencode+codex',
     ]);
+  });
+});
+
+describe('getPermissionFlags', () => {
+  describe('claude', () => {
+    it('returns no flags when permissionMode is empty (agent default)', () => {
+      expect(getPermissionFlags('claude', '')).toBe('');
+      expect(getPermissionFlags('claude', undefined)).toBe('');
+    });
+
+    it('returns acceptEdits flag', () => {
+      expect(getPermissionFlags('claude', 'acceptEdits')).toBe('--permission-mode acceptEdits');
+    });
+
+    it('returns plan mode flag', () => {
+      expect(getPermissionFlags('claude', 'plan')).toBe('--permission-mode plan');
+    });
+
+    it('returns dangerously-skip-permissions for bypassPermissions', () => {
+      expect(getPermissionFlags('claude', 'bypassPermissions')).toBe('--dangerously-skip-permissions');
+    });
+  });
+
+  describe('codex', () => {
+    it('returns no flags when permissionMode is empty (agent default)', () => {
+      expect(getPermissionFlags('codex', '')).toBe('');
+      expect(getPermissionFlags('codex', undefined)).toBe('');
+    });
+
+    it('returns auto-edit flag for acceptEdits', () => {
+      expect(getPermissionFlags('codex', 'acceptEdits')).toBe('--approval-mode auto-edit');
+    });
+
+    it('returns bypass flag for bypassPermissions', () => {
+      expect(getPermissionFlags('codex', 'bypassPermissions')).toBe('--dangerously-bypass-approvals-and-sandbox');
+    });
+
+    it('returns no flags for modes codex does not support', () => {
+      expect(getPermissionFlags('codex', 'plan')).toBe('');
+    });
+  });
+
+  describe('opencode', () => {
+    it('returns empty string for all modes', () => {
+      expect(getPermissionFlags('opencode', '')).toBe('');
+      expect(getPermissionFlags('opencode', undefined)).toBe('');
+      expect(getPermissionFlags('opencode', 'plan')).toBe('');
+      expect(getPermissionFlags('opencode', 'acceptEdits')).toBe('');
+      expect(getPermissionFlags('opencode', 'bypassPermissions')).toBe('');
+    });
   });
 });

--- a/docs/src/content/agents.js
+++ b/docs/src/content/agents.js
@@ -9,16 +9,16 @@ export function render() {
 
     <h3>Claude Code</h3>
     <p><a href="https://docs.anthropic.com/en/docs/claude-code" target="_blank" rel="noopener">Claude Code</a> is Anthropic's agentic coding tool. dmux launches it with:</p>
-    <pre><code data-lang="bash">claude --permission-mode=acceptEdits</code></pre>
-    <p>When autopilot is enabled, dmux adds the <code>--dangerously-skip-permissions</code> flag for fully autonomous operation.</p>
+    <pre><code data-lang="bash">claude --permission-mode acceptEdits</code></pre>
+    <p>You can configure the permission level in <a href="#/configuration">settings</a>, including using Claude's true default (ask for all permissions).</p>
 
     <h3>opencode</h3>
-    <p><a href="https://github.com/opencode-ai/opencode" target="_blank" rel="noopener">opencode</a> is an open-source coding agent. dmux launches it directly with your prompt.</p>
+    <p><a href="https://github.com/opencode-ai/opencode" target="_blank" rel="noopener">opencode</a> is an open-source coding agent. dmux launches it directly with your prompt. opencode has no permission flags.</p>
 
     <h3>Codex</h3>
     <p><a href="https://github.com/openai/codex" target="_blank" rel="noopener">Codex</a> is OpenAI's coding agent. dmux launches it with:</p>
-    <pre><code data-lang="bash">codex --approval-mode suggest</code></pre>
-    <p>When autopilot is enabled, dmux uses <code>--approval-mode full-auto</code> instead.</p>
+    <pre><code data-lang="bash">codex --approval-mode auto-edit</code></pre>
+    <p>You can configure the permission level in <a href="#/configuration">settings</a>.</p>
 
     <h2>Agent Detection</h2>
     <p>dmux automatically detects installed agents by searching:</p>
@@ -43,23 +43,28 @@ export function render() {
       <li><strong>API:</strong> <code>PATCH /api/settings</code> with <code>{"defaultAgent": "claude"}</code></li>
     </ul>
 
-    <h2>Autopilot Mode</h2>
-    <p>When <code>enableAutopilotByDefault</code> is enabled in <a href="#/configuration">settings</a>, agents are launched in their most autonomous mode:</p>
+    <h2>Permission Mode</h2>
+    <p>The <code>permissionMode</code> setting controls what permissions agents are granted when launched. Configure it via TUI (<kbd>s</kbd>), settings JSON, or the API.</p>
     <table>
       <thead>
-        <tr><th>Agent</th><th>Normal Mode</th><th>Autopilot Mode</th></tr>
+        <tr><th>Setting</th><th>Claude Code Flag</th><th>Codex Flag</th></tr>
       </thead>
       <tbody>
-        <tr><td>Claude Code</td><td><code>--permission-mode=acceptEdits</code></td><td><code>--dangerously-skip-permissions</code></td></tr>
-        <tr><td>opencode</td><td>(default)</td><td>(default)</td></tr>
-        <tr><td>Codex</td><td><code>--approval-mode suggest</code></td><td><code>--approval-mode full-auto</code></td></tr>
+        <tr><td>Agent default (ask for permissions)</td><td><em>(no flags)</em></td><td><em>(no flags)</em></td></tr>
+        <tr><td>Accept edits automatically</td><td><code>--permission-mode acceptEdits</code></td><td><code>--approval-mode auto-edit</code></td></tr>
+        <tr><td>Plan mode (Claude only)</td><td><code>--permission-mode plan</code></td><td><em>(no flags)</em></td></tr>
+        <tr><td>Bypass all permissions</td><td><code>--dangerously-skip-permissions</code></td><td><code>--dangerously-bypass-approvals-and-sandbox</code></td></tr>
       </tbody>
     </table>
+    <p>opencode has no permission flags — all modes map to no flags. The dmux default is "Accept edits automatically" — set to "Agent default" if you want agents to ask before every action.</p>
 
     <div class="callout callout-warning">
       <div class="callout-title">Caution</div>
-      Autopilot mode gives agents broad permissions to modify files and run commands without confirmation. Use it only in isolated environments where you trust the agent's actions.
+      "Bypass all permissions" gives agents broad permissions to modify files and run commands without confirmation. Use it only in isolated environments where you trust the agent's actions.
     </div>
+
+    <h2>Autopilot Mode</h2>
+    <p>When <code>enableAutopilotByDefault</code> is enabled in <a href="#/configuration">settings</a>, dmux automatically accepts agent options when no risk is detected. This is independent of the permission mode — autopilot controls dmux's behavior in response to agent prompts, while permission mode controls what the agent can do without asking.</p>
 
     <h2>Agent Status Detection</h2>
     <p>dmux monitors each agent pane to determine its current state. This is used to show status indicators in the sidebar and web dashboard.</p>

--- a/src/services/TmuxService.ts
+++ b/src/services/TmuxService.ts
@@ -568,7 +568,7 @@ export class TmuxService {
    * The command will be automatically quoted to prevent tmux from splitting on spaces.
    *
    * @example
-   * await tmuxService.sendShellCommand(paneId, 'claude "fix the bug" --dangerously-skip-permissions');
+   * await tmuxService.sendShellCommand(paneId, 'claude "fix the bug"');
    * await tmuxService.sendTmuxKeys(paneId, 'Enter'); // Then send Enter key
    *
    * @param paneId The tmux pane ID (e.g., "%1")

--- a/src/types.ts
+++ b/src/types.ts
@@ -70,6 +70,8 @@ export interface DmuxSettings {
   enableAutopilotByDefault?: boolean;
   // Agent selection
   defaultAgent?: 'claude' | 'opencode' | 'codex';
+  // Agent permission mode
+  permissionMode?: '' | 'plan' | 'acceptEdits' | 'bypassPermissions';
   // Tmux hooks for event-driven updates (low CPU)
   // true = use hooks, false = use polling, undefined = not yet asked
   useTmuxHooks?: boolean;

--- a/src/utils/agentLaunch.ts
+++ b/src/utils/agentLaunch.ts
@@ -1,3 +1,5 @@
+import type { DmuxSettings } from '../types.js';
+
 export type AgentName = 'claude' | 'opencode' | 'codex';
 
 export interface AgentLaunchOption {
@@ -43,6 +45,45 @@ export function appendSlugSuffix(baseSlug: string, slugSuffix?: string): string 
   }
 
   return `${baseSlug}-${normalizedSuffix}`;
+}
+
+/**
+ * Returns the CLI permission flags for a given agent and permission mode setting.
+ * Empty string means the agent's true default (no flags — asks for permissions).
+ * Config files default to 'acceptEdits' to preserve existing behavior.
+ */
+export function getPermissionFlags(
+  agent: AgentName,
+  permissionMode: DmuxSettings['permissionMode']
+): string {
+  const mode = permissionMode || '';
+
+  if (agent === 'claude') {
+    switch (mode) {
+      case 'acceptEdits':
+        return '--permission-mode acceptEdits';
+      case 'plan':
+        return '--permission-mode plan';
+      case 'bypassPermissions':
+        return '--dangerously-skip-permissions';
+      default:
+        return '';
+    }
+  }
+
+  if (agent === 'codex') {
+    switch (mode) {
+      case 'acceptEdits':
+        return '--approval-mode auto-edit';
+      case 'bypassPermissions':
+        return '--dangerously-bypass-approvals-and-sandbox';
+      default:
+        return '';
+    }
+  }
+
+  // opencode has no permission flags
+  return '';
 }
 
 export function buildAgentLaunchOptions(

--- a/src/utils/settingsManager.ts
+++ b/src/utils/settingsManager.ts
@@ -5,6 +5,11 @@ import type { DmuxSettings, SettingsScope, SettingDefinition } from '../types.js
 
 const GLOBAL_SETTINGS_PATH = join(homedir(), '.dmux.global.json');
 
+/** Defaults applied when no explicit value is set */
+const DEFAULT_SETTINGS: DmuxSettings = {
+  permissionMode: 'acceptEdits',
+};
+
 export const SETTING_DEFINITIONS: SettingDefinition[] = [
   {
     key: 'enableAutopilotByDefault',
@@ -22,6 +27,18 @@ export const SETTING_DEFINITIONS: SettingDefinition[] = [
       { value: 'claude', label: 'Claude Code' },
       { value: 'opencode', label: 'OpenCode' },
       { value: 'codex', label: 'Codex' },
+    ],
+  },
+  {
+    key: 'permissionMode',
+    label: 'Permission Mode',
+    description: 'Controls what permissions agents are granted when launched',
+    type: 'select',
+    options: [
+      { value: '', label: 'Agent default (ask for permissions)' },
+      { value: 'acceptEdits', label: 'Accept edits automatically' },
+      { value: 'plan', label: 'Plan mode (Claude only)' },
+      { value: 'bypassPermissions', label: 'Bypass all permissions' },
     ],
   },
   {
@@ -73,10 +90,11 @@ export class SettingsManager {
   }
 
   /**
-   * Get merged settings (project settings override global)
+   * Get merged settings (project settings override global, with defaults applied)
    */
   getSettings(): DmuxSettings {
     return {
+      ...DEFAULT_SETTINGS,
       ...this.globalSettings,
       ...this.projectSettings,
     };


### PR DESCRIPTION
## Summary

Closes #7

Replaces the hardcoded `--dangerously-skip-permissions` / `--dangerously-bypass-approvals-and-sandbox` flags with a configurable `permissionMode` setting. Users can now control what permissions agents are granted when launched, via TUI settings (`s`) or config files.

## Problem

Every agent launch path hardcoded the most permissive flags (`--dangerously-skip-permissions` for Claude, `--dangerously-bypass-approvals-and-sandbox` for Codex). There was no way to configure the permission mode.

## Solution

### New `permissionMode` setting

Added to `DmuxSettings` with four values:

| Value | Claude Code | Codex | opencode |
|---|---|---|---|
| `''` (empty) | No flags (agent default — asks for all permissions) | No flags | No flags |
| `plan` | `--permission-mode plan` | No flags (unsupported) | No flags |
| `acceptEdits` | `--permission-mode acceptEdits` | `--approval-mode auto-edit` | No flags |
| `bypassPermissions` | `--dangerously-skip-permissions` | `--dangerously-bypass-approvals-and-sandbox` | No flags |

**Default is `acceptEdits`** — more restrictive than the previous hardcoded `--dangerously-skip-permissions`, but a reasonable middle ground where agents can edit files without asking while still requesting approval for commands.

### Centralized `getPermissionFlags()` helper

A pure function in `src/utils/agentLaunch.ts` that maps `(agent, permissionMode) → CLI flags string`. All agent launch paths call this instead of hardcoding flags.

### Changes by file

- **`src/utils/agentLaunch.ts`** — New `getPermissionFlags()` function with per-agent flag mapping
- **`src/types.ts`** — Added `permissionMode` to `DmuxSettings` interface
- **`src/utils/settingsManager.ts`** — Added `DEFAULT_SETTINGS` with `permissionMode: 'acceptEdits'`, added setting definition with select options for the TUI settings UI
- **`src/utils/paneCreation.ts`** — Replaced hardcoded flags with `getPermissionFlags()` for Claude and Codex launch paths
- **`src/utils/conflictResolutionPane.ts`** — Same replacement for conflict resolution agent launches
- **`src/utils/reopenWorktree.ts`** — Same replacement for worktree reopen (resume session) launches
- **`src/components/panes/MergePane.tsx`** — Same replacement for merge conflict resolution Claude launch
- **`src/services/TmuxService.ts`** — Updated code comment (removed stale `--dangerously-skip-permissions` example)
- **`__tests__/agentLaunch.test.ts`** — 10 new test cases covering all agent × mode combinations
- **`docs/src/content/agents.js`** — Rewrote agents docs page: new permission mode table, separated autopilot from permission mode explanation
- **`CLAUDE.md`** — Updated settings docs and pane lifecycle description

### Design decisions

- **Agent-agnostic value names** (`acceptEdits`, `bypassPermissions`) rather than agent-specific flag names (`dangerously-skip-permissions`) — maps cleanly to different agents' CLI conventions
- **Empty string for agent default** rather than a named value — keeps config minimal and makes it clear no flags are passed
- **`acceptEdits` as default** rather than `bypassPermissions` — intentionally more restrictive than the old hardcoded behavior, since unrestricted access should be an opt-in choice
- **Autopilot remains independent** — `enableAutopilotByDefault` controls dmux's response to agent prompts; `permissionMode` controls what the agent can do without asking. These are orthogonal.

## Test plan

- [x] `pnpm test __tests__/agentLaunch.test.ts` — 13 tests pass (10 new)
- [x] Full test suite passes (1 pre-existing failure on `main` in `gitOperations.test.ts` — unrelated)
- [x] Manual: create pane with each permissionMode value, verify correct flags in launched command
- [x] Manual: change setting via TUI (`s`)

> **Note:** The HTTP server / web dashboard is currently not wired up (removed in `ef81c95` on `main`). Settings API endpoints exist but are unreachable until the server is re-enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)