### PR TITLE
feat: attach multiple agents to the same worktree

### DIFF
--- a/src/DmuxApp.tsx
+++ b/src/DmuxApp.tsx
@@ -780,6 +780,8 @@ const DmuxApp: React.FC<DmuxAppProps> = ({
     savePanes,
     loadPanes,
     cleanExit,
+    availableAgents,
+    panesFile,
     projectRoot: sessionProjectRoot,
     projectActionItems: projectActionLayout.actionItems,
     findCardInDirection,

--- a/src/actions/implementations/index.ts
+++ b/src/actions/implementations/index.ts
@@ -12,3 +12,7 @@ export { duplicatePane } from './duplicateAction.js';
 export { copyPath } from './copyPathAction.js';
 export { openInEditor } from './openInEditorAction.js';
 export { toggleAutopilot } from './toggleAutopilotAction.js';
+
+// attachAgent is handled directly via the 'a' keyboard shortcut in useInputHandling.
+// This stub exists to document the action in the system.
+export { attachAgentToWorktree as attachAgent } from '../../utils/attachAgent.js';

--- a/src/actions/types.ts
+++ b/src/actions/types.ts
@@ -106,6 +106,7 @@ export enum PaneAction {
   COPY_PATH = 'copy_path',
   OPEN_IN_EDITOR = 'open_in_editor',
   TOGGLE_AUTOPILOT = 'toggle_autopilot',
+  ATTACH_AGENT = 'attach_agent',
 }
 
 /**
@@ -208,6 +209,13 @@ export const ACTION_REGISTRY: Record<PaneAction, ActionMetadata> = {
     label: 'Toggle Autopilot',
     description: 'Enable/disable automatic option acceptance',
     icon: '🤖',
+    requires: { worktree: true },
+  },
+  [PaneAction.ATTACH_AGENT]: {
+    id: PaneAction.ATTACH_AGENT,
+    label: 'Attach Agent',
+    description: 'Attach another agent to this worktree',
+    icon: '+',
     shortcut: 'a',
     requires: { worktree: true },
   },
@@ -217,6 +225,7 @@ const HIDDEN_MENU_ACTIONS = new Set<PaneAction>([
   PaneAction.DUPLICATE,
   PaneAction.RUN_TEST,
   PaneAction.RUN_DEV,
+  PaneAction.ATTACH_AGENT,
 ]);
 
 /**

--- a/src/components/panes/PaneCard.tsx
+++ b/src/components/panes/PaneCard.tsx
@@ -9,9 +9,10 @@ interface PaneCardProps {
   isFirstPane: boolean;
   isLastPane: boolean;
   isNextSelected: boolean;
+  siblingCount: number;
 }
 
-const PaneCard: React.FC<PaneCardProps> = memo(({ pane, selected, isFirstPane, isLastPane, isNextSelected }) => {
+const PaneCard: React.FC<PaneCardProps> = memo(({ pane, selected, isFirstPane, isLastPane, isNextSelected, siblingCount }) => {
   // Get status indicator
   const getStatusIcon = () => {
     if (pane.agentStatus === 'working') return { icon: '✻', color: COLORS.working };
@@ -54,6 +55,9 @@ const PaneCard: React.FC<PaneCardProps> = memo(({ pane, selected, isFirstPane, i
           {pane.autopilot && (
             <Text color={COLORS.success}> (ap)</Text>
           )}
+          {siblingCount > 0 && (
+            <Text color="gray"> ({siblingCount + 1})</Text>
+          )}
         </Box>
         <Text color={borderColor}> │</Text>
       </Box>
@@ -79,7 +83,8 @@ const PaneCard: React.FC<PaneCardProps> = memo(({ pane, selected, isFirstPane, i
     prevProps.selected === nextProps.selected &&
     prevProps.isFirstPane === nextProps.isFirstPane &&
     prevProps.isLastPane === nextProps.isLastPane &&
-    prevProps.isNextSelected === nextProps.isNextSelected
+    prevProps.isNextSelected === nextProps.isNextSelected &&
+    prevProps.siblingCount === nextProps.siblingCount
   );
 });
 

--- a/src/components/panes/PanesGrid.tsx
+++ b/src/components/panes/PanesGrid.tsx
@@ -32,6 +32,17 @@ const PanesGrid: React.FC<PanesGridProps> = memo(({
   )
   const paneGroups = actionLayout.groups
 
+  // Compute sibling count map: how many other panes share the same worktree
+  const siblingCountMap = useMemo(() => {
+    const map = new Map<string, number>()
+    for (const pane of panes) {
+      if (!pane.worktreePath) continue
+      const count = panes.filter(p => p.worktreePath === pane.worktreePath).length - 1
+      map.set(pane.id, count)
+    }
+    return map
+  }, [panes])
+
   const actionsByProject = useMemo(() => {
     const map = new Map<string, { newAgent?: ProjectActionItem; terminal?: ProjectActionItem }>()
     for (const action of actionLayout.actionItems) {
@@ -99,6 +110,7 @@ const PanesGrid: React.FC<PanesGridProps> = memo(({
                 isFirstPane={isFirstPane}
                 isLastPane={isLastPane}
                 isNextSelected={isNextSelected}
+                siblingCount={siblingCountMap.get(pane.id) || 0}
               />
             )
           })}

--- a/src/components/popups/shortcutsPopup.tsx
+++ b/src/components/popups/shortcutsPopup.tsx
@@ -39,6 +39,7 @@ const ShortcutsPopupApp: React.FC<ShortcutsPopupAppProps> = ({
     { key: 'j', description: 'Jump to selected pane' },
     { key: 'm', description: 'Open kebab menu for selected pane' },
     { key: 'x', description: 'Close selected pane' },
+    { key: 'a', description: 'Attach agent to selected worktree' },
     { key: 'n', description: 'Create new pane (main project)' },
     { key: 't', description: 'Create terminal pane (main project)' },
     { key: 'p', description: 'Create pane in another project' },

--- a/src/services/PopupManager.ts
+++ b/src/services/PopupManager.ts
@@ -405,7 +405,7 @@ export class PopupManager {
         [],
         {
           width: 50,
-          height: 21,
+          height: 22,
           title: "⌨️  Keyboard Shortcuts",
         },
         {

--- a/src/utils/attachAgent.ts
+++ b/src/utils/attachAgent.ts
@@ -1,0 +1,174 @@
+/**
+ * Attach a second (or Nth) agent to an existing worktree pane.
+ *
+ * Creates a new tmux pane that `cd`s into the same worktree directory,
+ * launches the chosen agent, and returns a sibling DmuxPane that shares
+ * the same worktreePath/branchName/projectRoot.
+ */
+
+import * as fs from 'fs';
+import path from 'path';
+import type { DmuxPane, DmuxConfig } from '../types.js';
+import type { AgentName } from './agentLaunch.js';
+import { launchAgentInPane } from './agentLaunch.js';
+import { autoApproveTrustPrompt } from './paneCreation.js';
+import { TmuxService } from '../services/TmuxService.js';
+import { splitPane, getTerminalDimensions } from './tmux.js';
+import { recalculateAndApplyLayout } from './layoutManager.js';
+import { buildWorktreePaneTitle } from './paneTitle.js';
+import { SettingsManager } from './settingsManager.js';
+import { LogService } from '../services/LogService.js';
+
+export interface AttachAgentOptions {
+  targetPane: DmuxPane;
+  prompt: string;
+  agent: AgentName;
+  existingPanes: DmuxPane[];
+  sessionProjectRoot: string;
+  sessionConfigPath: string;
+}
+
+/**
+ * Generate a unique sibling slug like `fix-auth-a2`, `fix-auth-a3`, etc.
+ */
+function generateSiblingSlug(baseSlug: string, existingPanes: DmuxPane[]): string {
+  const existingSlugs = new Set(existingPanes.map(p => p.slug));
+  let n = 2;
+  while (existingSlugs.has(`${baseSlug}-a${n}`)) {
+    n++;
+  }
+  return `${baseSlug}-a${n}`;
+}
+
+export async function attachAgentToWorktree(
+  options: AttachAgentOptions
+): Promise<{ pane: DmuxPane }> {
+  const {
+    targetPane,
+    prompt,
+    agent,
+    existingPanes,
+    sessionProjectRoot,
+    sessionConfigPath,
+  } = options;
+
+  if (!targetPane.worktreePath) {
+    throw new Error('Target pane has no worktree to attach to');
+  }
+
+  const projectRoot = targetPane.projectRoot || sessionProjectRoot;
+  const settingsManager = new SettingsManager(projectRoot);
+  const settings = settingsManager.getSettings();
+
+  // Generate a unique slug for this sibling
+  const slug = generateSiblingSlug(targetPane.slug, existingPanes);
+
+  const tmuxService = TmuxService.getInstance();
+  const originalPaneId = tmuxService.getCurrentPaneIdSync();
+
+  // Load config to get control pane info
+  let controlPaneId: string | undefined;
+  try {
+    const configContent = fs.readFileSync(sessionConfigPath, 'utf-8');
+    const config: DmuxConfig = JSON.parse(configContent);
+    controlPaneId = config.controlPaneId;
+  } catch {
+    controlPaneId = originalPaneId;
+  }
+
+  // Split from the last existing pane (standard grid placement)
+  const dmuxPaneIds = existingPanes.map(p => p.paneId);
+  const splitTarget = dmuxPaneIds[dmuxPaneIds.length - 1];
+  const paneInfo = splitPane({ targetPane: splitTarget, cwd: projectRoot });
+
+  // Wait for pane to be ready
+  const start = Date.now();
+  while ((Date.now() - start) < 600) {
+    if (await tmuxService.paneExists(paneInfo)) break;
+    await new Promise(r => setTimeout(r, 30));
+  }
+
+  // Set pane title
+  try {
+    const paneProjectName = targetPane.projectName || path.basename(projectRoot);
+    const paneTitle = projectRoot === sessionProjectRoot
+      ? slug
+      : buildWorktreePaneTitle(slug, projectRoot, paneProjectName);
+    await tmuxService.setPaneTitle(paneInfo, paneTitle);
+  } catch {
+    // Ignore title errors
+  }
+
+  // Recalculate layout
+  if (controlPaneId) {
+    const dimensions = getTerminalDimensions();
+    const allContentPaneIds = [...existingPanes.map(p => p.paneId), paneInfo];
+    await recalculateAndApplyLayout(
+      controlPaneId,
+      allContentPaneIds,
+      dimensions.width,
+      dimensions.height,
+    );
+    await tmuxService.refreshClient();
+  }
+
+  // cd into the existing worktree (no git worktree add)
+  const cdCmd = `cd "${targetPane.worktreePath}"`;
+  await tmuxService.sendShellCommand(paneInfo, cdCmd);
+  await tmuxService.sendTmuxKeys(paneInfo, 'Enter');
+
+  // Small delay for cd to complete
+  await new Promise(r => setTimeout(r, 300));
+
+  // Launch the agent
+  await launchAgentInPane({
+    paneId: paneInfo,
+    agent,
+    prompt,
+    slug,
+    projectRoot,
+    permissionMode: settings.permissionMode,
+  });
+
+  // Auto-approve trust prompts for Claude
+  if (agent === 'claude') {
+    autoApproveTrustPrompt(paneInfo, prompt).catch(() => {
+      // Ignore errors in background monitoring
+    });
+  }
+
+  // Keep focus on the new pane
+  await tmuxService.selectPane(paneInfo);
+
+  // Build the sibling pane object — shares worktree/branch with target
+  const newPane: DmuxPane = {
+    id: `dmux-${Date.now()}`,
+    slug,
+    branchName: targetPane.branchName,
+    prompt: prompt || 'No initial prompt',
+    paneId: paneInfo,
+    projectRoot,
+    projectName: targetPane.projectName,
+    worktreePath: targetPane.worktreePath,
+    agent,
+    autopilot: settings.enableAutopilotByDefault ?? false,
+  };
+
+  // Switch focus back to control pane
+  await tmuxService.selectPane(originalPaneId);
+
+  // Re-set the dmux sidebar title
+  try {
+    const sessionProjectName = path.basename(sessionProjectRoot);
+    await tmuxService.setPaneTitle(originalPaneId, `dmux-${sessionProjectName}`);
+  } catch {
+    // Ignore title errors
+  }
+
+  LogService.getInstance().info(
+    `Attached ${agent} to worktree ${targetPane.worktreePath} as ${slug}`,
+    'attachAgent',
+  );
+
+  return { pane: newPane };
+}


### PR DESCRIPTION
## Summary

Allows attaching additional agents to an existing worktree pane via the `a` keyboard shortcut, enabling review, pairing, and task decomposition workflows. Siblings share the same worktree, branch, and project root but run independently.

- **`a` keyboard shortcut**: Select a worktree pane → pick agent → enter prompt → new sibling pane launches in the same worktree
- **Sibling badge**: Pane cards show a gray `(N)` count when multiple agents share a worktree
- **Sibling-aware close**: Only the last sibling triggers worktree/branch cleanup; earlier closes just remove the pane
- **Sibling-aware merge**: Warns about active siblings before merging, kills them all on confirm, then proceeds with normal merge flow
- **Extracted `launchAgentInPane()`**: Reusable agent launch helper shared by both `createPane()` and `attachAgentToWorktree()`

Closes #17

## Test plan

- [x] `pnpm build` compiles cleanly
- [x] Create a pane with `n`, select it, press `a` → agent picker → prompt → new sibling pane opens in same worktree
- [x] Pane cards show `(2)` badge for siblings
- [x] Close one sibling with `x` → worktree survives (other sibling still using it)
- [x] Close last sibling → worktree is cleaned up
- [ ] Merge a pane with siblings → warning appears, siblings closed, merge proceeds
- [ ] Press `a` on a shell pane (no worktree) → shows error message
- [ ] Sibling slugs increment correctly: `{slug}-a2`, `{slug}-a3`, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)