### PR TITLE
fix: show [cx] badge for codex panes instead of [oc]

### DIFF
--- a/src/components/panes/PaneCard.tsx
+++ b/src/components/panes/PaneCard.tsx
@@ -49,7 +49,7 @@ const PaneCard: React.FC<PaneCardProps> = memo(({ pane, selected, isFirstPane, i
           {pane.type === 'shell' ? (
             <Text color="cyan"> [{pane.shellType || 'shell'}]</Text>
           ) : pane.agent && (
-            <Text color="gray"> [{pane.agent === 'claude' ? 'cc' : 'oc'}]</Text>
+            <Text color="gray"> [{pane.agent === 'claude' ? 'cc' : pane.agent === 'codex' ? 'cx' : 'oc'}]</Text>
           )}
           {pane.autopilot && (
             <Text color={COLORS.success}> (ap)</Text>


### PR DESCRIPTION
## Summary

- The agent badge in `PaneCard` used a two-way ternary (`claude ? 'cc' : 'oc'`), causing codex panes to incorrectly display `[oc]` instead of `[cx]`
- Fixed to a three-way ternary: `claude → cc`, `codex → cx`, `opencode → oc`

## Test plan

- [ ] Create a codex pane and verify it shows `[cx]` in the sidebar
- [ ] Create a claude pane and verify it still shows `[cc]`
- [ ] Create an opencode pane and verify it still shows `[oc]`