### PR TITLE
feat: add focused mode for single-pane full-screen viewing

### DIFF
--- a/src/components/panes/PaneCard.tsx
+++ b/src/components/panes/PaneCard.tsx
@@ -8,6 +8,7 @@ interface PaneCardProps {
   pane: DmuxPane;
   isDevSource: boolean;
   selected: boolean;
+  isFocused?: boolean;
 }
 
 const ROW_WIDTH = 40;
@@ -33,7 +34,7 @@ const clipToWidth = (value: string, maxWidth: number): string => {
   return clipped;
 };
 
-const PaneCard: React.FC<PaneCardProps> = memo(({ pane, isDevSource, selected }) => {
+const PaneCard: React.FC<PaneCardProps> = memo(({ pane, isDevSource, selected, isFocused }) => {
   // Get status indicator
   const getStatusIcon = () => {
     if (pane.agentStatus === 'working') return { icon: '✻', color: COLORS.working };
@@ -56,7 +57,7 @@ const PaneCard: React.FC<PaneCardProps> = memo(({ pane, isDevSource, selected })
   const apTag = pane.autopilot ? 'ap' : null;
 
   // Keep non-title segments fixed; only slug is allowed to clip.
-  const prefix = selected ? '▸' : ' ';
+  const prefix = isFocused ? '◆' : selected ? '▸' : ' ';
   const statusText = `${status.icon} `;
   const sourceText = isDevSource ? '★ ' : '';
   const agentText = hasAgent ? ` [${agentTag}]` : '     ';
@@ -101,7 +102,8 @@ const PaneCard: React.FC<PaneCardProps> = memo(({ pane, isDevSource, selected })
     prevProps.pane.shellType === nextProps.pane.shellType &&
     prevProps.pane.agent === nextProps.pane.agent &&
     prevProps.isDevSource === nextProps.isDevSource &&
-    prevProps.selected === nextProps.selected
+    prevProps.selected === nextProps.selected &&
+    prevProps.isFocused === nextProps.isFocused
   );
 });
 

--- a/src/components/panes/PanesGrid.tsx
+++ b/src/components/panes/PanesGrid.tsx
@@ -18,6 +18,8 @@ interface PanesGridProps {
   activeDevSourcePath?: string
   fallbackProjectRoot: string
   fallbackProjectName: string
+  focusedMode?: boolean
+  focusedPaneIndex?: number
 }
 
 const PanesGrid: React.FC<PanesGridProps> = memo(({
@@ -28,6 +30,8 @@ const PanesGrid: React.FC<PanesGridProps> = memo(({
   activeDevSourcePath,
   fallbackProjectRoot,
   fallbackProjectName,
+  focusedMode,
+  focusedPaneIndex,
 }) => {
   const actionLayout = useMemo(
     () => buildProjectActionLayout(panes, fallbackProjectRoot, fallbackProjectName),
@@ -135,7 +139,7 @@ const PanesGrid: React.FC<PanesGridProps> = memo(({
                 pane={paneWithStatus}
                 isDevSource={isDevSource}
                 selected={isSelected}
-
+                isFocused={focusedMode && paneIndex === focusedPaneIndex}
               />
             )
           })}

--- a/src/components/ui/FooterHelp.tsx
+++ b/src/components/ui/FooterHelp.tsx
@@ -12,6 +12,7 @@ interface FooterHelpProps {
   currentToast?: Toast | null;
   toastQueueLength?: number;
   toastQueuePosition?: number | null;
+  focusedMode?: boolean;
 }
 
 const FooterHelp: React.FC<FooterHelpProps> = memo(({
@@ -22,7 +23,8 @@ const FooterHelp: React.FC<FooterHelpProps> = memo(({
   unreadWarningCount = 0,
   currentToast,
   toastQueueLength = 0,
-  toastQueuePosition
+  toastQueuePosition,
+  focusedMode = false
 }) => {
   if (!show) return null;
 
@@ -132,7 +134,10 @@ const FooterHelp: React.FC<FooterHelpProps> = memo(({
 
       {/* Keyboard shortcuts */}
       <Text dimColor>
-        Press <Text color="cyan">[?]</Text> for keyboard shortcuts
+        Press <Text color="cyan">[?]</Text> for shortcuts
+        <Text>  </Text>
+        <Text color="cyan">[f]</Text>{focusedMode ? ' grid' : ' focus'}
+        {focusedMode && <Text>  <Text color="cyan">[Tab]</Text> cycle</Text>}
       </Text>
 
       {/* Debug info */}

--- a/src/hooks/useLayoutManagement.ts
+++ b/src/hooks/useLayoutManagement.ts
@@ -6,6 +6,8 @@ import { LogService } from '../services/LogService.js';
 interface LayoutManagementOptions {
   controlPaneId: string | undefined;
   hasActiveDialog: boolean;
+  focusedMode?: boolean;
+  focusedPaneId?: string;
 }
 
 /**
@@ -15,6 +17,8 @@ interface LayoutManagementOptions {
 export function useLayoutManagement({
   controlPaneId,
   hasActiveDialog,
+  focusedMode,
+  focusedPaneId,
 }: LayoutManagementOptions) {
   // Use refs to track state across resize events
   const resizeTimeoutRef = useRef<NodeJS.Timeout | null>(null);
@@ -30,7 +34,7 @@ export function useLayoutManagement({
     }
 
     // Enforce sidebar width immediately on mount (with error handling)
-    enforceControlPaneSize(controlPaneId, SIDEBAR_WIDTH).catch(error => {
+    enforceControlPaneSize(controlPaneId, SIDEBAR_WIDTH, { focusedMode, focusedPaneId }).catch(error => {
       LogService.getInstance().warn(
         `Initial layout enforcement failed: ${error}`,
         'ResizeDebug'
@@ -65,7 +69,7 @@ export function useLayoutManagement({
 
           try {
             // Only enforce sidebar width when terminal resizes
-            await enforceControlPaneSize(controlPaneId, SIDEBAR_WIDTH);
+            await enforceControlPaneSize(controlPaneId, SIDEBAR_WIDTH, { focusedMode, focusedPaneId });
 
             // Check if still mounted before updating UI
             if (!isMountedRef.current) {
@@ -106,5 +110,5 @@ export function useLayoutManagement({
         clearTimeout(resizeTimeoutRef.current);
       }
     };
-  }, [controlPaneId, hasActiveDialog]);
+  }, [controlPaneId, hasActiveDialog, focusedMode, focusedPaneId]);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -93,6 +93,8 @@ export interface DmuxSettings {
   minPaneWidth?: number;
   // Preferred maximum content pane width in characters
   maxPaneWidth?: number;
+  // Focused mode: show one pane full-size, others minimized
+  focusedMode?: boolean;
 }
 
 export type SettingsScope = 'global' | 'project';

--- a/src/utils/settingsManager.ts
+++ b/src/utils/settingsManager.ts
@@ -51,6 +51,7 @@ const DEFAULT_SETTINGS: DmuxSettings = {
   minPaneWidth: DEFAULT_MIN_PANE_WIDTH,
   maxPaneWidth: DEFAULT_MAX_PANE_WIDTH,
   enabledAgents: getDefaultEnabledAgents(),
+  focusedMode: false,
 };
 
 const AGENT_OPTIONS = getAgentDefinitions().map((agent) => ({


### PR DESCRIPTION
## Summary

- Add **focused mode** (`f` key) that displays one pane at full terminal height while minimizing all others to 1-row strips
- **Tab/Shift+Tab** cycles through focused panes; `f` again returns to grid mode
- Handles edge cases: 0 panes (no-op), 1 pane (identical to grid), deleted focused pane (auto-fallback), terminal too small (auto-revert to grid)

## Changes

### Layout Engine
- `generateSidebarFocusedLayout()` in `src/utils/tmux.ts` — generates tmux layout string with sidebar | focused pane (full height) | minimized stack (1 row each)
- Focused mode branch in `recalculateAndApplyLayout()` — skips spacer/grid logic, directly applies focused layout
- `enforceControlPaneSize()` passes `focusedMode`/`focusedPaneId` through the layout chain

### Input Handling
- `f` key toggles between grid and focused mode
- `Tab`/`Shift+Tab` cycles focused pane in focused mode
- Arrow keys sync `focusedPaneIndex` when in focused mode

### UI
- `◆` prefix on focused pane in sidebar (PaneCard `isFocused` prop)
- Footer shows `[f] focus` / `[f] grid` + `[Tab] cycle` hints
- `focusedMode` state in DmuxApp with proper cleanup on pane removal

## Test plan

- [ ] `pnpm build` compiles without errors
- [ ] `pnpm typecheck` passes
- [ ] Open 3+ agent panes, press `f` to enter focused mode
- [ ] Verify one pane is full-screen, others minimized to 1 row
- [ ] Tab cycles through focused panes
- [ ] Press `f` again to return to grid mode
- [ ] Close the focused pane — verify auto-fallback to previous pane
- [ ] Test with 0 and 1 pane — no crash, graceful behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)