### PR TITLE
feat: add fish shell support for prompt bootstrap

### DIFF
--- a/src/utils/promptStore.ts
+++ b/src/utils/promptStore.ts
@@ -92,5 +92,12 @@ export async function cleanupPromptFilesForSlug(
 
 export function buildPromptReadAndDeleteSnippet(promptPath: string): string {
   const quotedPromptPath = shellQuote(promptPath);
+  if (isFishShell(process.env.SHELL)) {
+    return `set DMUX_PROMPT_FILE ${quotedPromptPath}; set DMUX_PROMPT_CONTENT "$(cat "$DMUX_PROMPT_FILE" 2>/dev/null || true)"; rm -f "$DMUX_PROMPT_FILE"`;
+  }
   return `DMUX_PROMPT_FILE=${quotedPromptPath}; DMUX_PROMPT_CONTENT="$(cat "$DMUX_PROMPT_FILE" 2>/dev/null || true)"; rm -f "$DMUX_PROMPT_FILE"`;
+}
+
+function isFishShell(shellPath?: string): boolean {
+  return path.basename(shellPath || '').toLowerCase() === 'fish';
 }


### PR DESCRIPTION
## Summary

- Add fish shell detection to `buildPromptReadAndDeleteSnippet` so prompt bootstrap uses `set VAR value` instead of `VAR=value` when the user's shell is fish
- Requires fish 3.4+ for `$()` command substitution support

## Context

Fish shell does not support `VAR=value` standalone assignment syntax. The existing `buildPromptReadAndDeleteSnippet` generates a shell snippet sent to tmux panes via `send-keys`. When the pane runs fish, the `VAR=value` syntax fails silently, causing the agent to launch without a prompt.

Other shell constructs used by dmux (`&&`, `||`, `$()`, `2>/dev/null`) are supported in fish 3.0+/3.4+, so only the variable assignment syntax needed a fish-specific code path.

Relates to #31

## Test plan

- [x] `pnpm run typecheck` passes
- [x] `pnpm run test` passes (4 pre-existing failures unrelated to this change)
- [x] Tested manually with fish 4.5.0 — agent prompt delivery works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)