### PR TITLE
feat: add per-agent custom CLI arguments via agentArgs setting

### DIFF
--- a/__tests__/agentLaunch.test.ts
+++ b/__tests__/agentLaunch.test.ts
@@ -182,4 +182,60 @@ describe('command builders', () => {
       'gemini --resume latest --approval-mode yolo'
     );
   });
+
+  describe('custom args (agentArgs)', () => {
+    it('appends custom args to buildAgentCommand', () => {
+      expect(buildAgentCommand('claude', 'acceptEdits', '--model sonnet')).toBe(
+        'claude --permission-mode acceptEdits --model sonnet'
+      );
+    });
+
+    it('appends custom args to buildAgentCommand without permission flags', () => {
+      expect(buildAgentCommand('claude', '', '--verbose')).toBe(
+        'claude --verbose'
+      );
+    });
+
+    it('appends custom args to buildInitialPromptCommand (positional)', () => {
+      expect(buildInitialPromptCommand('claude', '"fix it"', 'bypassPermissions', '--model sonnet')).toBe(
+        'claude --dangerously-skip-permissions --model sonnet "fix it"'
+      );
+    });
+
+    it('appends custom args to buildInitialPromptCommand (option)', () => {
+      expect(buildInitialPromptCommand('gemini', '"fix it"', 'bypassPermissions', '--sandbox none')).toBe(
+        'gemini --approval-mode yolo --sandbox none --prompt-interactive "fix it"'
+      );
+    });
+
+    it('appends custom args to buildInitialPromptCommand (stdin)', () => {
+      expect(buildInitialPromptCommand('amp', '"fix it"', 'bypassPermissions', '--verbose')).toBe(
+        "printf '%s\\n' \"fix it\" | amp --dangerously-allow-all --verbose"
+      );
+    });
+
+    it('appends custom args to buildInitialPromptCommand (send-keys)', () => {
+      expect(buildInitialPromptCommand('crush', '"fix it"', 'bypassPermissions', '--extra')).toBe(
+        'crush --yolo --extra'
+      );
+    });
+
+    it('appends custom args to buildResumeCommand', () => {
+      expect(buildResumeCommand('claude', 'bypassPermissions', '--model sonnet')).toBe(
+        'claude --continue --dangerously-skip-permissions --model sonnet'
+      );
+    });
+
+    it('does not append when customArgs is undefined', () => {
+      expect(buildAgentCommand('claude', 'acceptEdits', undefined)).toBe(
+        'claude --permission-mode acceptEdits'
+      );
+    });
+
+    it('does not append when customArgs is empty string', () => {
+      expect(buildAgentCommand('claude', 'acceptEdits', '')).toBe(
+        'claude --permission-mode acceptEdits'
+      );
+    });
+  });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -93,6 +93,8 @@ export interface DmuxSettings {
   minPaneWidth?: number;
   // Preferred maximum content pane width in characters
   maxPaneWidth?: number;
+  // Custom CLI arguments per agent (e.g. {"claude": "--model sonnet", "codex": "--model gpt-4"})
+  agentArgs?: Partial<Record<AgentName, string>>;
 }
 
 export type SettingsScope = 'global' | 'project';

--- a/src/utils/agentLaunch.ts
+++ b/src/utils/agentLaunch.ts
@@ -470,27 +470,32 @@ export function getPermissionFlags(
 
 export function buildAgentCommand(
   agent: AgentName,
-  permissionMode: PermissionMode | undefined
+  permissionMode: PermissionMode | undefined,
+  customArgs?: string
 ): string {
   const definition = AGENT_REGISTRY[agent];
   const baseCommand = definition.noPromptCommand || definition.promptCommand;
-  return appendFlags(baseCommand, getPermissionFlags(agent, permissionMode));
+  let cmd = appendFlags(baseCommand, getPermissionFlags(agent, permissionMode));
+  if (customArgs) cmd = appendFlags(cmd, customArgs);
+  return cmd;
 }
 
 export function buildInitialPromptCommand(
   agent: AgentName,
   promptToken: string,
-  permissionMode: PermissionMode | undefined
+  permissionMode: PermissionMode | undefined,
+  customArgs?: string
 ): string {
   const definition = AGENT_REGISTRY[agent];
   if (definition.promptTransport === 'send-keys') {
-    return buildAgentCommand(agent, permissionMode);
+    return buildAgentCommand(agent, permissionMode, customArgs);
   }
 
-  const baseCommand = appendFlags(
+  let baseCommand = appendFlags(
     definition.promptCommand,
     getPermissionFlags(agent, permissionMode)
   );
+  if (customArgs) baseCommand = appendFlags(baseCommand, customArgs);
 
   if (definition.promptTransport === 'stdin') {
     return `printf '%s\\n' ${promptToken} | ${baseCommand}`;
@@ -505,7 +510,8 @@ export function buildInitialPromptCommand(
 
 export function buildResumeCommand(
   agent: AgentName,
-  permissionMode: PermissionMode | undefined
+  permissionMode: PermissionMode | undefined,
+  customArgs?: string
 ): string | undefined {
   const template = AGENT_REGISTRY[agent].resumeCommandTemplate;
   if (!template) return undefined;
@@ -513,11 +519,15 @@ export function buildResumeCommand(
   const permissionFlags = getPermissionFlags(agent, permissionMode);
   const permissionSuffix = permissionFlags ? ` ${permissionFlags}` : '';
 
+  let cmd: string;
   if (template.includes('{permissions}')) {
-    return template.replace('{permissions}', permissionSuffix);
+    cmd = template.replace('{permissions}', permissionSuffix);
+  } else {
+    cmd = appendFlags(template, permissionFlags);
   }
 
-  return appendFlags(template, permissionFlags);
+  if (customArgs) cmd = appendFlags(cmd, customArgs);
+  return cmd;
 }
 
 /**
@@ -533,14 +543,16 @@ export async function launchAgentInPane(opts: {
   slug: string;
   projectRoot: string;
   permissionMode?: '' | 'plan' | 'acceptEdits' | 'bypassPermissions';
+  customArgs?: string;
 }): Promise<void> {
-  const { paneId, agent, prompt, slug, projectRoot, permissionMode } = opts;
+  const { paneId, agent, prompt, slug, projectRoot, permissionMode, customArgs } = opts;
   const tmuxService = TmuxService.getInstance();
   const hasInitialPrompt = !!(prompt && prompt.trim());
 
   if (agent === 'claude') {
     const permissionFlags = getPermissionFlags('claude', permissionMode);
     const permissionSuffix = permissionFlags ? ` ${permissionFlags}` : '';
+    const customSuffix = customArgs ? ` ${customArgs}` : '';
     let claudeCmd: string;
     if (hasInitialPrompt) {
       let promptFilePath: string | null = null;
@@ -552,23 +564,24 @@ export async function launchAgentInPane(opts: {
 
       if (promptFilePath) {
         const promptBootstrap = buildPromptReadAndDeleteSnippet(promptFilePath);
-        claudeCmd = `${promptBootstrap}; claude "$DMUX_PROMPT_CONTENT"${permissionSuffix}`;
+        claudeCmd = `${promptBootstrap}; claude "$DMUX_PROMPT_CONTENT"${permissionSuffix}${customSuffix}`;
       } else {
         const escapedPrompt = prompt
           .replace(/\\/g, '\\\\')
           .replace(/"/g, '\\"')
           .replace(/`/g, '\\`')
           .replace(/\$/g, '\\$');
-        claudeCmd = `claude "${escapedPrompt}"${permissionSuffix}`;
+        claudeCmd = `claude "${escapedPrompt}"${permissionSuffix}${customSuffix}`;
       }
     } else {
-      claudeCmd = `claude${permissionSuffix}`;
+      claudeCmd = `claude${permissionSuffix}${customSuffix}`;
     }
     await tmuxService.sendShellCommand(paneId, claudeCmd);
     await tmuxService.sendTmuxKeys(paneId, 'Enter');
   } else if (agent === 'codex') {
     const permissionFlags = getPermissionFlags('codex', permissionMode);
     const permissionSuffix = permissionFlags ? ` ${permissionFlags}` : '';
+    const customSuffix = customArgs ? ` ${customArgs}` : '';
     let codexCmd: string;
     if (hasInitialPrompt) {
       let promptFilePath: string | null = null;
@@ -580,21 +593,22 @@ export async function launchAgentInPane(opts: {
 
       if (promptFilePath) {
         const promptBootstrap = buildPromptReadAndDeleteSnippet(promptFilePath);
-        codexCmd = `${promptBootstrap}; codex "$DMUX_PROMPT_CONTENT"${permissionSuffix}`;
+        codexCmd = `${promptBootstrap}; codex "$DMUX_PROMPT_CONTENT"${permissionSuffix}${customSuffix}`;
       } else {
         const escapedPrompt = prompt
           .replace(/\\/g, '\\\\')
           .replace(/"/g, '\\"')
           .replace(/`/g, '\\`')
           .replace(/\$/g, '\\$');
-        codexCmd = `codex "${escapedPrompt}"${permissionSuffix}`;
+        codexCmd = `codex "${escapedPrompt}"${permissionSuffix}${customSuffix}`;
       }
     } else {
-      codexCmd = `codex${permissionSuffix}`;
+      codexCmd = `codex${permissionSuffix}${customSuffix}`;
     }
     await tmuxService.sendShellCommand(paneId, codexCmd);
     await tmuxService.sendTmuxKeys(paneId, 'Enter');
   } else if (agent === 'opencode') {
+    const customSuffix = customArgs ? ` ${customArgs}` : '';
     let opencodeCmd: string;
     if (hasInitialPrompt) {
       let promptFilePath: string | null = null;
@@ -606,17 +620,17 @@ export async function launchAgentInPane(opts: {
 
       if (promptFilePath) {
         const promptBootstrap = buildPromptReadAndDeleteSnippet(promptFilePath);
-        opencodeCmd = `${promptBootstrap}; opencode --prompt "$DMUX_PROMPT_CONTENT"`;
+        opencodeCmd = `${promptBootstrap}; opencode --prompt "$DMUX_PROMPT_CONTENT"${customSuffix}`;
       } else {
         const escapedPrompt = prompt
           .replace(/\\/g, '\\\\')
           .replace(/"/g, '\\"')
           .replace(/`/g, '\\`')
           .replace(/\$/g, '\\$');
-        opencodeCmd = `opencode --prompt "${escapedPrompt}"`;
+        opencodeCmd = `opencode --prompt "${escapedPrompt}"${customSuffix}`;
       }
     } else {
-      opencodeCmd = 'opencode';
+      opencodeCmd = `opencode${customSuffix}`;
     }
     await tmuxService.sendShellCommand(paneId, opencodeCmd);
     await tmuxService.sendTmuxKeys(paneId, 'Enter');

--- a/src/utils/attachAgent.ts
+++ b/src/utils/attachAgent.ts
@@ -143,6 +143,7 @@ export async function attachAgentToWorktree(
     slug,
     projectRoot,
     permissionMode: settings.permissionMode,
+    customArgs: settings.agentArgs?.[agent] || undefined,
   });
 
   // Auto-approve trust prompts for Claude

--- a/src/utils/conflictResolutionPane.ts
+++ b/src/utils/conflictResolutionPane.ts
@@ -141,13 +141,15 @@ export async function createConflictResolutionPane(
       }
     }
 
+    const customArgs = settings.agentArgs?.[agent] || undefined;
     let launchCommand: string;
     if (promptFilePath && !shouldSendPromptViaTmux) {
       const promptBootstrap = buildPromptReadAndDeleteSnippet(promptFilePath);
       launchCommand = `${promptBootstrap}; ${buildInitialPromptCommand(
         agent,
         '"$DMUX_PROMPT_CONTENT"',
-        settings.permissionMode
+        settings.permissionMode,
+        customArgs
       )}`;
       promptFilePath = null;
     } else {
@@ -159,12 +161,13 @@ export async function createConflictResolutionPane(
       launchCommand = buildInitialPromptCommand(
         agent,
         `"${escapedPrompt}"`,
-        settings.permissionMode
+        settings.permissionMode,
+        customArgs
       );
     }
 
     if (!launchCommand) {
-      launchCommand = buildAgentCommand(agent, settings.permissionMode);
+      launchCommand = buildAgentCommand(agent, settings.permissionMode, customArgs);
     }
 
     await tmuxService.sendShellCommand(paneInfo, launchCommand);

--- a/src/utils/paneCreation.ts
+++ b/src/utils/paneCreation.ts
@@ -452,6 +452,7 @@ export async function createPane(
       }
     }
 
+    const customArgs = settings.agentArgs?.[agent] || undefined;
     let launchCommand: string;
     if (hasInitialPrompt && !shouldSendPromptViaTmux) {
       let promptFilePath: string | null = null;
@@ -466,7 +467,8 @@ export async function createPane(
         launchCommand = `${promptBootstrap}; ${buildInitialPromptCommand(
           agent,
           '"$DMUX_PROMPT_CONTENT"',
-          settings.permissionMode
+          settings.permissionMode,
+          customArgs
         )}`;
       } else {
         const escapedPrompt = prompt
@@ -477,11 +479,12 @@ export async function createPane(
         launchCommand = buildInitialPromptCommand(
           agent,
           `"${escapedPrompt}"`,
-          settings.permissionMode
+          settings.permissionMode,
+          customArgs
         );
       }
     } else {
-      launchCommand = buildAgentCommand(agent, settings.permissionMode);
+      launchCommand = buildAgentCommand(agent, settings.permissionMode, customArgs);
     }
 
     await tmuxService.sendShellCommand(paneInfo, launchCommand);

--- a/src/utils/reopenWorktree.ts
+++ b/src/utils/reopenWorktree.ts
@@ -167,9 +167,10 @@ export async function reopenWorktree(
       ensureGeminiFolderTrusted(worktreePath);
     }
 
+    const agentCustomArgs = settings.agentArgs?.[agent] || undefined;
     const resumeCommand =
-      buildResumeCommand(agent, settings.permissionMode)
-      || buildAgentCommand(agent, settings.permissionMode);
+      buildResumeCommand(agent, settings.permissionMode, agentCustomArgs)
+      || buildAgentCommand(agent, settings.permissionMode, agentCustomArgs);
     await tmuxService.sendShellCommand(paneInfo, resumeCommand);
     await tmuxService.sendTmuxKeys(paneInfo, 'Enter');
   }

--- a/src/utils/settingsManager.ts
+++ b/src/utils/settingsManager.ts
@@ -44,6 +44,20 @@ function isValidMinPaneWidth(value: unknown): value is number {
   );
 }
 
+function validateAgentArgs(value: unknown): void {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error('Invalid agentArgs: expected an object mapping agent IDs to argument strings');
+  }
+  for (const [key, val] of Object.entries(value)) {
+    if (!isAgentName(key)) {
+      throw new Error(`Invalid agentArgs: unknown agent "${key}"`);
+    }
+    if (typeof val !== 'string') {
+      throw new Error(`Invalid agentArgs: value for "${key}" must be a string`);
+    }
+  }
+}
+
 const DEFAULT_SETTINGS: DmuxSettings = {
   // Most permissive defaults for new dmux setups.
   permissionMode: 'bypassPermissions',
@@ -285,6 +299,9 @@ export class SettingsManager {
         throw new Error(`Invalid enabledAgents: ${invalidAgents.join(', ')}`);
       }
     }
+    if (key === 'agentArgs') {
+      validateAgentArgs(value);
+    }
     if (key === 'minPaneWidth' && !isValidMinPaneWidth(value)) {
       throw new Error(
         `Invalid minPaneWidth: expected an integer between ${MIN_MIN_PANE_WIDTH} and ${MAX_MIN_PANE_WIDTH}`
@@ -357,6 +374,9 @@ export class SettingsManager {
     }
     if (typeof settings.branchPrefix === 'string' && settings.branchPrefix !== '' && !isValidBranchName(settings.branchPrefix)) {
       throw new Error('Invalid branchPrefix: contains characters not allowed in git branch names');
+    }
+    if (settings.agentArgs !== undefined) {
+      validateAgentArgs(settings.agentArgs);
     }
     if (settings.minPaneWidth !== undefined && !isValidMinPaneWidth(settings.minPaneWidth)) {
       throw new Error(


### PR DESCRIPTION
## Summary

- Adds a new `agentArgs` setting to `.dmux.global.json` (and per-project `.dmux/settings.json`) that allows specifying custom CLI arguments per agent
- Custom arguments are appended to agent commands across all launch paths: initial prompt, no-prompt, resume, conflict resolution, and attach-agent
- Includes input validation and 9 new tests covering all prompt transport types

### Example config

```json
{
  "agentArgs": {
    "gemini": "--model gemini-3.1-pro-preview",
    "claude": "--model sonnet"
  }
}
```

### Motivation

Some agents don't default to the desired model. For example, `gemini` CLI doesn't show `gemini-3.1-pro-preview` by default, so `--model gemini-3.1-pro-preview` needs to be passed manually. This setting automates that across all dmux launch flows.

## Test plan

- [x] `tsc --noEmit` passes
- [x] All 34 tests pass (9 new tests for custom args across positional, option, stdin, send-keys transports, and resume commands)
- [ ] Manual: set `agentArgs` in `~/.dmux.global.json` and verify args appear in launched agent commands