### PR TITLE
Fix merge blocked by dmux's own .dmux/ and .dmux-hooks/ dirs

### DIFF
--- a/__tests__/mergeValidation.test.ts
+++ b/__tests__/mergeValidation.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { execSync } from 'child_process';
+import { getGitStatus } from '../src/utils/mergeValidation.js';
+
+vi.mock('child_process', () => ({
+  execSync: vi.fn(),
+}));
+
+describe('mergeValidation', () => {
+  beforeEach(() => {
+    vi.mocked(execSync).mockReset();
+  });
+
+  it('ignores dmux metadata directories when checking git status', () => {
+    vi.mocked(execSync).mockReturnValue(
+      '?? .dmux/\nM  .dmux/worktrees/feature-a\n'
+    );
+
+    const status = getGitStatus('/repo');
+
+    expect(status).toEqual({
+      hasChanges: false,
+      files: [],
+      summary: '',
+    });
+  });
+
+  it('ignores untracked hook scaffolding but preserves real hook changes', () => {
+    vi.mocked(execSync).mockReturnValue(
+      [
+        '?? .dmux-hooks/',
+        '?? .dmux-hooks/AGENTS.md',
+        '?? .dmux-hooks/examples/pre_merge.example',
+        ' M .dmux-hooks/pre_merge',
+        '?? .dmux-hooks/custom_hook',
+      ].join('\n')
+    );
+
+    const status = getGitStatus('/repo');
+
+    expect(status).toEqual({
+      hasChanges: true,
+      files: [
+        '.dmux-hooks/pre_merge',
+        '.dmux-hooks/custom_hook',
+      ],
+      summary: ' M .dmux-hooks/pre_merge\n?? .dmux-hooks/custom_hook',
+    });
+  });
+
+  it('keeps non-dmux files in the dirty-state result', () => {
+    vi.mocked(execSync).mockReturnValue(
+      ' M src/index.ts\nM package.json\n'
+    );
+
+    const status = getGitStatus('/repo');
+
+    expect(status).toEqual({
+      hasChanges: true,
+      files: ['src/index.ts', 'package.json'],
+      summary: 'M src/index.ts\nM package.json',
+    });
+  });
+});

--- a/src/utils/hooks.ts
+++ b/src/utils/hooks.ts
@@ -275,50 +275,6 @@ export function listAvailableHooks(projectRoot: string): HookType[] {
 }
 
 /**
- * Ensure .dmux/ and .dmux-hooks/ are listed in the project's .gitignore.
- * Runs once per project init — skips if entries already present.
- */
-function ensureGitignoreEntries(projectRoot: string): void {
-  const gitignorePath = path.join(projectRoot, '.gitignore');
-
-  // Only add entries in git repos
-  if (!existsSync(path.join(projectRoot, '.git'))) {
-    return;
-  }
-
-  const entriesToAdd = ['.dmux/', '.dmux-hooks/'];
-
-  try {
-    let content = '';
-    if (existsSync(gitignorePath)) {
-      content = readFileSync(gitignorePath, 'utf-8');
-    }
-
-    const lines = content.split('\n');
-    const missing = entriesToAdd.filter(
-      (entry) => !lines.some((line) => line.trim() === entry)
-    );
-
-    if (missing.length === 0) {
-      return;
-    }
-
-    const suffix = content.length > 0 && !content.endsWith('\n') ? '\n' : '';
-    const block = `${suffix}\n# dmux\n${missing.join('\n')}\n`;
-    writeFileSync(gitignorePath, content + block, 'utf-8');
-    LogService.getInstance().debug(
-      `Added ${missing.join(', ')} to .gitignore`,
-      'hooks'
-    );
-  } catch (error) {
-    LogService.getInstance().warn(
-      `Failed to update .gitignore: ${error instanceof Error ? error.message : String(error)}`,
-      'hooks'
-    );
-  }
-}
-
-/**
  * Initialize .dmux-hooks/ directory with documentation and examples
  * This gets called the first time hooks are accessed or when user explicitly initializes
  */
@@ -345,9 +301,6 @@ export function initializeHooksDirectory(projectRoot: string): void {
 
   const initMsg = 'Initializing .dmux-hooks/ directory (or repairing missing docs)...';
   LogService.getInstance().debug(initMsg, 'hooks');
-
-  // Ensure .dmux/ and .dmux-hooks/ are gitignored before creating any files
-  ensureGitignoreEntries(projectRoot);
 
   try {
     let madeChanges = false;

--- a/src/utils/hooks.ts
+++ b/src/utils/hooks.ts
@@ -275,6 +275,50 @@ export function listAvailableHooks(projectRoot: string): HookType[] {
 }
 
 /**
+ * Ensure .dmux/ and .dmux-hooks/ are listed in the project's .gitignore.
+ * Runs once per project init — skips if entries already present.
+ */
+function ensureGitignoreEntries(projectRoot: string): void {
+  const gitignorePath = path.join(projectRoot, '.gitignore');
+
+  // Only add entries in git repos
+  if (!existsSync(path.join(projectRoot, '.git'))) {
+    return;
+  }
+
+  const entriesToAdd = ['.dmux/', '.dmux-hooks/'];
+
+  try {
+    let content = '';
+    if (existsSync(gitignorePath)) {
+      content = readFileSync(gitignorePath, 'utf-8');
+    }
+
+    const lines = content.split('\n');
+    const missing = entriesToAdd.filter(
+      (entry) => !lines.some((line) => line.trim() === entry)
+    );
+
+    if (missing.length === 0) {
+      return;
+    }
+
+    const suffix = content.length > 0 && !content.endsWith('\n') ? '\n' : '';
+    const block = `${suffix}\n# dmux\n${missing.join('\n')}\n`;
+    writeFileSync(gitignorePath, content + block, 'utf-8');
+    LogService.getInstance().debug(
+      `Added ${missing.join(', ')} to .gitignore`,
+      'hooks'
+    );
+  } catch (error) {
+    LogService.getInstance().warn(
+      `Failed to update .gitignore: ${error instanceof Error ? error.message : String(error)}`,
+      'hooks'
+    );
+  }
+}
+
+/**
  * Initialize .dmux-hooks/ directory with documentation and examples
  * This gets called the first time hooks are accessed or when user explicitly initializes
  */
@@ -301,6 +345,9 @@ export function initializeHooksDirectory(projectRoot: string): void {
 
   const initMsg = 'Initializing .dmux-hooks/ directory (or repairing missing docs)...';
   LogService.getInstance().debug(initMsg, 'hooks');
+
+  // Ensure .dmux/ and .dmux-hooks/ are gitignored before creating any files
+  ensureGitignoreEntries(projectRoot);
 
   try {
     let madeChanges = false;

--- a/src/utils/mergeValidation.ts
+++ b/src/utils/mergeValidation.ts
@@ -28,6 +28,46 @@ export interface GitStatus {
   summary: string;
 }
 
+const DMUX_HOOK_SCAFFOLD_PATHS = new Set([
+  '.dmux-hooks',
+  '.dmux-hooks/',
+  '.dmux-hooks/AGENTS.md',
+  '.dmux-hooks/CLAUDE.md',
+  '.dmux-hooks/README.md',
+  '.dmux-hooks/examples',
+  '.dmux-hooks/examples/',
+]);
+
+function parseGitStatusLine(line: string): { statusCode: string; filename: string } {
+  const trimmed = line.trimStart();
+  const spaceIndex = trimmed.indexOf(' ');
+  const filename = spaceIndex >= 0 ? trimmed.slice(spaceIndex + 1).trim() : trimmed;
+
+  return {
+    statusCode: line.slice(0, 2),
+    filename,
+  };
+}
+
+function shouldIgnoreGitStatusEntry(statusCode: string, filename: string): boolean {
+  if (
+    filename === '.dmux'
+    || filename === '.dmux/'
+    || filename.startsWith('.dmux/')
+  ) {
+    return true;
+  }
+
+  if (statusCode !== '??') {
+    return false;
+  }
+
+  return (
+    DMUX_HOOK_SCAFFOLD_PATHS.has(filename)
+    || filename.startsWith('.dmux-hooks/examples/')
+  );
+}
+
 /**
  * Get git status for a repository
  */
@@ -40,31 +80,43 @@ export function getGitStatus(repoPath: string): GitStatus {
       stdio: 'pipe',
     });
 
-    const files = statusOutput
+    const entries = statusOutput
       .trim()
       .split('\n')
       .filter(line => line.trim())
-      // Ignore dmux's own metadata directories — they are managed by dmux
-      // and should never block merge validation
-      .filter(line => !line.includes('.dmux/') && !line.includes('.dmux-hooks/'))
       .map(line => {
-        // Git status porcelain format can vary:
-        // Standard: " M filename" (2 status chars + space + filename)
-        // Sometimes: "M filename" (1 status char + space + filename)
-        // Solution: trim leading spaces, find first space, take everything after it and trim again
-        const trimmed = line.trimStart();
-        const spaceIndex = trimmed.indexOf(' ');
-        const filename = spaceIndex >= 0 ? trimmed.slice(spaceIndex + 1).trim() : trimmed;
-        LogService.getInstance().info(`Git status: "${line}" → "${filename}"`, 'mergeValidation');
-        return filename;
+        const parsed = parseGitStatusLine(line);
+        LogService.getInstance().info(
+          `Git status: "${line}" → "${parsed.filename}"`,
+          'mergeValidation'
+        );
+        return { line, ...parsed };
       });
 
-    LogService.getInstance().info(`Final files for ${repoPath}: ${JSON.stringify(files)}`, 'mergeValidation');
+    const visibleEntries = entries
+      .filter(({ statusCode, filename, line }) => {
+        const shouldIgnore = shouldIgnoreGitStatusEntry(statusCode, filename);
+        if (shouldIgnore) {
+          LogService.getInstance().info(
+            `Ignoring git status entry: "${line}"`,
+            'mergeValidation'
+          );
+        }
+        return !shouldIgnore;
+      });
+
+    const files = visibleEntries
+      .map(({ filename }) => filename);
+
+    LogService.getInstance().info(
+      `Final files for ${repoPath}: ${JSON.stringify(files)}`,
+      'mergeValidation'
+    );
 
     return {
       hasChanges: files.length > 0,
       files,
-      summary: statusOutput.trim(),
+      summary: visibleEntries.map(({ line }) => line).join('\n'),
     };
   } catch (error) {
     return {

--- a/src/utils/mergeValidation.ts
+++ b/src/utils/mergeValidation.ts
@@ -44,6 +44,9 @@ export function getGitStatus(repoPath: string): GitStatus {
       .trim()
       .split('\n')
       .filter(line => line.trim())
+      // Ignore dmux's own metadata directories — they are managed by dmux
+      // and should never block merge validation
+      .filter(line => !line.includes('.dmux/') && !line.includes('.dmux-hooks/'))
       .map(line => {
         // Git status porcelain format can vary:
         // Standard: " M filename" (2 status chars + space + filename)


### PR DESCRIPTION
## Summary

- Adds `ensureGitignoreEntries()` to `initializeHooksDirectory()` that appends `.dmux/` and `.dmux-hooks/` to the user project's `.gitignore` on first init (matching dmux's own `.gitignore`)
- Filters `.dmux*` paths from `getGitStatus()` in merge validation as a defensive fallback

## Problem

When dmux initializes in a user project, it creates `.dmux/` and `.dmux-hooks/` but doesn't gitignore them. This causes merge validation to detect them as uncommitted changes, blocking the merge with "master has uncommitted changes that must be committed or stashed before merge."

After the user commits those files, `.dmux/worktrees/<name>` still shows as modified (submodule-like reference with untracked content), but `git add` can't stage it — creating an unresolvable loop where merge validation demands a commit but nothing can be staged.

Fixes #56

## Test plan

- [ ] Open dmux in a git repo that has no `.dmux/` or `.dmux-hooks/` in `.gitignore`
- [ ] Verify `.gitignore` gets updated with both entries on first pane init
- [ ] Create a worktree, make commits, and merge via dmux menu — should succeed without dirty-state blocking
- [ ] Verify existing projects that already have the entries in `.gitignore` are not duplicated

🤖 Generated with [Claude Code](https://claude.com/claude-code)