### PR TITLE
feat: add team defaults config layer (.dmux.defaults.json)

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -118,6 +118,7 @@ export interface DmuxSettings {
 }
 
 export type SettingsScope = 'global' | 'project';
+export type EffectiveSettingsScope = SettingsScope | 'team';
 
 export interface SettingDefinition {
   key: keyof DmuxSettings | string;

--- a/src/utils/settingsManager.ts
+++ b/src/utils/settingsManager.ts
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
 import { dirname, join } from 'path';
 import { homedir } from 'os';
-import type { DmuxSettings, SettingsScope, SettingDefinition } from '../types.js';
+import type { DmuxSettings, SettingsScope, EffectiveSettingsScope, SettingDefinition } from '../types.js';
 import {
   DEFAULT_MIN_PANE_WIDTH,
   DEFAULT_MAX_PANE_WIDTH,
@@ -26,6 +26,7 @@ import {
 } from './notificationSounds.js';
 
 const GLOBAL_SETTINGS_PATH = join(homedir(), '.dmux.global.json');
+const TEAM_DEFAULTS_FILENAME = '.dmux.defaults.json';
 const PERMISSION_MODES = ['', 'plan', 'acceptEdits', 'bypassPermissions'] as const;
 function isPermissionMode(value: string): value is NonNullable<DmuxSettings['permissionMode']> {
   return (PERMISSION_MODES as readonly string[]).includes(value);
@@ -181,16 +182,30 @@ export const SETTING_DEFINITIONS: SettingDefinition[] = [
 export class SettingsManager {
   private globalPath: string;
   private projectPath: string;
+  private teamDefaultsPath: string;
   private globalSettings: DmuxSettings = {};
   private projectSettings: DmuxSettings = {};
+  private teamDefaults: DmuxSettings = {};
 
   constructor(projectRoot?: string) {
+    const root = projectRoot || process.cwd();
     this.globalPath = GLOBAL_SETTINGS_PATH;
-    this.projectPath = join(projectRoot || process.cwd(), '.dmux', 'settings.json');
+    this.projectPath = join(root, '.dmux', 'settings.json');
+    this.teamDefaultsPath = join(root, TEAM_DEFAULTS_FILENAME);
     this.loadSettings();
   }
 
   private loadSettings(): void {
+    // Load team defaults (committed to repo, read-only)
+    if (existsSync(this.teamDefaultsPath)) {
+      try {
+        const data = readFileSync(this.teamDefaultsPath, 'utf-8');
+        this.teamDefaults = JSON.parse(data);
+      } catch (error) {
+        console.error('Failed to load team defaults:', error);
+      }
+    }
+
     // Load global settings
     if (existsSync(this.globalPath)) {
       try {
@@ -249,11 +264,12 @@ export class SettingsManager {
   }
 
   /**
-   * Get merged settings (project settings override global)
+   * Get merged settings (project > global > team defaults > built-in defaults)
    */
   getSettings(): DmuxSettings {
     const merged = cloneSettingsArrays({
       ...DEFAULT_SETTINGS,
+      ...this.teamDefaults,
       ...this.globalSettings,
       ...this.projectSettings,
     });
@@ -526,9 +542,16 @@ export class SettingsManager {
   }
 
   /**
+   * Get team defaults (committed to repo, read-only)
+   */
+  getTeamDefaults(): DmuxSettings {
+    return cloneSettingsArrays(this.teamDefaults);
+  }
+
+  /**
    * Get the effective scope for a setting (where it's currently defined)
    */
-  getEffectiveScope(key: keyof DmuxSettings): SettingsScope | null {
+  getEffectiveScope(key: keyof DmuxSettings): EffectiveSettingsScope | null {
     if (key === 'minPaneWidth') {
       return this.globalSettings.minPaneWidth !== undefined ? 'global' : null;
     }
@@ -537,6 +560,7 @@ export class SettingsManager {
     }
     if (key in this.projectSettings) return 'project';
     if (key in this.globalSettings) return 'global';
+    if (key in this.teamDefaults) return 'team';
     return null;
   }
 }


### PR DESCRIPTION
## Summary

Adds a new settings layer: a `.dmux.defaults.json` file at the project root, intended to be committed to the repo. This lets teams share default settings (e.g. `baseBranch`, `branchPrefix`) without requiring each member to configure them individually.

**Precedence order** (highest to lowest):
1. `.dmux/settings.json` (project, gitignored) — personal overrides
2. `~/.dmux.global.json` (global) — user preferences
3. **`.dmux.defaults.json` (project root, committed)** — team defaults ← new
4. Built-in defaults

**Example** — a team that always branches from `origin/main`:
```json
{
  "baseBranch": "origin/main"
}
```

Any teammate who clones the repo gets this default automatically. They can still override it via their personal `.dmux/settings.json` or `~/.dmux.global.json`.

### Changes
- `src/types.ts` — added `EffectiveSettingsScope` type (`'team'` variant)
- `src/utils/settingsManager.ts`:
  - Loads `.dmux.defaults.json` from project root on init (read-only)
  - Inserts team defaults into the merge chain between global settings and built-in defaults
  - `getTeamDefaults()` getter
  - `getEffectiveScope()` returns `'team'` when a value originates from team defaults

## Test plan
- [ ] Create `.dmux.defaults.json` with `{"baseBranch": "origin/main"}` in a repo root
- [ ] Verify new panes branch from `origin/main` without any personal config
- [ ] Verify personal `.dmux/settings.json` or `~/.dmux.global.json` overrides team defaults
- [ ] Verify no `.dmux.defaults.json` → behavior unchanged (no regression)
- [ ] `pnpm run typecheck` passes