### PR TITLE
fix: always destroy welcome pane when creating/reopening a pane

### DIFF
--- a/src/utils/paneCreation.ts
+++ b/src/utils/paneCreation.ts
@@ -587,8 +587,9 @@ export async function createPane(
     mergeTargetChain,
   };
 
-  // CRITICAL: Save the pane to config IMMEDIATELY before destroying welcome pane
-  // This is the event that triggers welcome pane destruction (event-based, no polling)
+  // CRITICAL: Save the pane to config IMMEDIATELY before destroying welcome pane.
+  // Only needed for the first content pane — ensures loadPanes sees a pane in config
+  // before we kill the welcome pane (prevents spurious "0 panes" welcome recreation).
   if (isFirstContentPane) {
     try {
       const configContent = fs.readFileSync(configPath, 'utf-8');
@@ -598,13 +599,20 @@ export async function createPane(
       config.panes = [...existingPanes, newPane];
       config.lastUpdated = new Date().toISOString();
       atomicWriteJsonSync(configPath, config);
-
-      // NOW destroy the welcome pane (event-based destruction)
-      const { destroyWelcomePaneCoordinated } = await import('./welcomePaneManager.js');
-      destroyWelcomePaneCoordinated(sessionProjectRoot);
     } catch (error) {
       // Log but don't fail - welcome pane cleanup is not critical
     }
+  }
+
+  // Always destroy the welcome pane if one exists in config.
+  // We do this unconditionally because shell panes detected by detectAndAddShellPanes
+  // can make existingPanes.length > 0 even when no real content panes exist yet,
+  // which causes isFirstContentPane to be false and skips welcome pane destruction.
+  try {
+    const { destroyWelcomePaneCoordinated } = await import('./welcomePaneManager.js');
+    destroyWelcomePaneCoordinated(sessionProjectRoot);
+  } catch {
+    // Ignore - welcome pane cleanup is not critical
   }
 
   // Trigger worktree_created hook (after full pane setup)

--- a/src/utils/reopenWorktree.ts
+++ b/src/utils/reopenWorktree.ts
@@ -204,7 +204,8 @@ export async function reopenWorktree(
     mergeTargetChain: metadata?.mergeTargetChain,
   };
 
-  // Handle welcome pane destruction if first content pane
+  // Pre-save pane to config before destroying welcome pane (first content pane only),
+  // so loadPanes sees a pane in config and doesn't recreate the welcome pane.
   if (isFirstContentPane) {
     try {
       const configContent = fs.readFileSync(configPath, 'utf-8');
@@ -213,12 +214,18 @@ export async function reopenWorktree(
       config.panes = [...existingPanes, newPane];
       config.lastUpdated = new Date().toISOString();
       atomicWriteJsonSync(configPath, config);
-
-      const { destroyWelcomePaneCoordinated } = await import('./welcomePaneManager.js');
-      destroyWelcomePaneCoordinated(sessionProjectRoot);
     } catch {
       // Log but don't fail
     }
+  }
+
+  // Always destroy welcome pane if one exists — shell panes can make isFirstContentPane
+  // false even when no real content pane exists yet.
+  try {
+    const { destroyWelcomePaneCoordinated } = await import('./welcomePaneManager.js');
+    destroyWelcomePaneCoordinated(sessionProjectRoot);
+  } catch {
+    // Ignore - welcome pane cleanup is not critical
   }
 
   // Switch back to the original pane


### PR DESCRIPTION
## Summary

- `detectAndAddShellPanes` can inflate `existingPanes.length`, making `isFirstContentPane` false even when no real content pane exists yet
- This caused `destroyWelcomePaneCoordinated` to be skipped, leaving the UI stuck on the welcome screen after creating or reopening a pane
- Fix separates the config pre-save (still first-content-pane only, to prevent welcome recreation) from the destroy call, which now runs unconditionally

Affects both `createPane` (`paneCreation.ts`) and `reopenWorktree` (`reopenWorktree.ts`).

## Test plan

- [ ] Open dmux in a project that has existing shell panes detected on startup
- [ ] Create a new agent pane — confirm the welcome screen is replaced correctly
- [ ] Reopen a closed worktree — confirm the welcome screen is replaced correctly
- [ ] Open dmux in a fresh project with no existing panes — confirm normal welcome pane → first pane flow still works