### PR TITLE
fix: preserve startup command paths with spaces when sending tmux keys

### DIFF
--- a/__tests__/tmuxSendKeys.test.ts
+++ b/__tests__/tmuxSendKeys.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { spawnSyncMock } = vi.hoisted(() => ({
+  spawnSyncMock: vi.fn(),
+}));
+
+vi.mock('child_process', () => ({
+  spawnSync: spawnSyncMock,
+}));
+
+import { sendTmuxShellCommand } from '../src/utils/tmuxSendKeys.js';
+
+describe('sendTmuxShellCommand', () => {
+  beforeEach(() => {
+    spawnSyncMock.mockReset();
+  });
+
+  it('passes startup commands as a single tmux argument', () => {
+    spawnSyncMock.mockReturnValue({ status: 0 });
+    const commandWithSpaces = '"/Users/me/Library/Application Support/fnm/bin/dmux"';
+
+    sendTmuxShellCommand('dmux-demo', commandWithSpaces, 'inherit');
+
+    expect(spawnSyncMock).toHaveBeenCalledWith(
+      'tmux',
+      ['send-keys', '-t', 'dmux-demo', commandWithSpaces, 'Enter'],
+      { stdio: 'inherit' }
+    );
+  });
+
+  it('throws when tmux send-keys fails', () => {
+    spawnSyncMock.mockReturnValue({ status: 1 });
+
+    expect(() => sendTmuxShellCommand('dmux-demo', 'dmux')).toThrow(
+      'Failed to send tmux command to target dmux-demo'
+    );
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ import { shouldUseQuietDevWatchExit } from './utils/devWatchExit.js';
 import { buildPaneExitedHookCommandForSession } from './utils/tmuxHookCommands.js';
 import { ensureTmuxRuntimeCompatibility } from './utils/tmuxRuntimeCompatibility.js';
 import { claimProcessShutdown } from './utils/processShutdown.js';
+import { sendTmuxShellCommand } from './utils/tmuxSendKeys.js';
 import {
   addSidebarProject,
   hasSidebarProject,
@@ -318,7 +319,7 @@ class Dmux {
           }
         }
 
-        execSync(`tmux send-keys -t ${this.sessionName} "${dmuxCommand}" Enter`, { stdio: 'inherit' });
+        sendTmuxShellCommand(this.sessionName, dmuxCommand, 'inherit');
       }
       execSync(`tmux attach-session -t ${this.sessionName}`, { stdio: 'inherit' });
       return;

--- a/src/utils/tmuxSendKeys.ts
+++ b/src/utils/tmuxSendKeys.ts
@@ -1,0 +1,17 @@
+import { spawnSync } from 'child_process';
+
+export function sendTmuxShellCommand(
+  target: string,
+  command: string,
+  stdio: 'pipe' | 'inherit' = 'pipe'
+): void {
+  const result = spawnSync(
+    'tmux',
+    ['send-keys', '-t', target, command, 'Enter'],
+    { stdio }
+  );
+
+  if (result.status !== 0) {
+    throw new Error(`Failed to send tmux command to target ${target}`);
+  }
+}


### PR DESCRIPTION
## Summary

- Replace string-built `tmux send-keys` startup invocation with an argument-safe helper using `spawnSync`, so startup commands are passed as a single token.
- Fix a path-quoting edge case where executable paths under directories like `Library/Application Support` could be mangled during dmux startup.
- Add regression coverage for command paths with spaces and non-zero `tmux send-keys` failures.

## Test plan

- [x] `fnm exec --using=24 pnpm install`
- [x] `fnm exec --using=24 pnpm run typecheck`
- [x] `fnm exec --using=24 pnpm exec vitest run __tests__/tmuxSendKeys.test.ts`
- [ ] Manual smoke test: run `dmux` from a machine where Node/bin paths include spaces and verify startup succeeds