### PR TITLE
Fix: CJK text wrapping, cursor positioning, and startup UI freeze

### DIFF
--- a/__tests__/actions/openInEditorAction.test.ts
+++ b/__tests__/actions/openInEditorAction.test.ts
@@ -26,6 +26,7 @@ describe('openInEditorAction', () => {
   });
 
   it('should open worktree in default editor (code)', async () => {
+    delete process.env.EDITOR;
     const mockPane = createMockPane({
       worktreePath: '/test/worktree/path',
     });
@@ -119,6 +120,7 @@ describe('openInEditorAction', () => {
   });
 
   it('should handle paths with spaces and special characters', async () => {
+    delete process.env.EDITOR;
     const mockPane = createMockPane({
       worktreePath: '/test/path with spaces/worktree',
     });

--- a/__tests__/input.utils.test.ts
+++ b/__tests__/input.utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { preprocessPastedContent, wrapText, findCursorInWrappedLines } from '../src/utils/input.js';
+import { preprocessPastedContent, wrapText, findCursorInWrappedLines, findCharIndexAtWidth } from '../src/utils/input.js';
 import stringWidth from 'string-width';
 
 describe('input utils: paste sanitation', () => {
@@ -143,26 +143,20 @@ describe('input utils: CJK cursor mapping', () => {
     const text = '你好世界测试';
     const wrapped = wrapText(text, 8); // "你好世界" (4 chars) | "测试" (2 chars)
     // gapSize is 0 for forced CJK break, so cursor=4 should be on line 1, col 0
+    // (the character '测' is at absolute index 4 and starts line 1)
     const pos = findCursorInWrappedLines(wrapped, 4);
-    expect(pos.line).toBe(0);
-    expect(pos.col).toBe(4);
-    // cursor=4 is at end of line 0 (after '界')
-    // cursor just past the line should go to next line
-    // With gapSize 0, character 4 ('测') starts line 1
-    // But cursor=4 <= 0+4 so it's still on line 0. Cursor 4 on line 0 is at end.
+    expect(pos.line).toBe(1);
+    expect(pos.col).toBe(0);
   });
 
   it('cursor after CJK forced break maps to start of next line', () => {
     const text = '你好世界测试';
     const wrapped = wrapText(text, 8); // "你好世界" | "测试", gapSize=0
-    // With gapSize=0, the 5th character '测' is at absolute position 4
-    // currentPos after line 0: 0 + 4 + 0 = 4
-    // cursor=4 <= 0+4, so line 0, col 4 (end of line)
-    // But we also need cursor=4 to show on line 1 col 0 since char 4 is there
-    // Actually, cursor=4 at col=4 of a 4-char line means "after last char" = end of line 0
-    // The character at index 4 starts on the next line
-    expect(wrapped[0].line.length).toBe(4);
-    expect(wrapped[1].line).toBe('测试');
+    // cursor=4 maps to line 1, col 0 ('测')
+    const pos = findCursorInWrappedLines(wrapped, 4);
+    expect(pos.line).toBe(1);
+    expect(pos.col).toBe(0);
+    expect(wrapped[1].line[0]).toBe('测');
   });
 
   it('maps cursor in mixed ASCII/CJK wrapped text', () => {
@@ -175,5 +169,107 @@ describe('input utils: CJK cursor mapping', () => {
     const pos = findCursorInWrappedLines(wrapped, 6);
     expect(pos.line).toBe(1);
     expect(pos.col).toBe(0);
+  });
+});
+
+describe('input utils: CJK forced break boundary correctness', () => {
+  it('every cursor position renders the correct character via right arrow', () => {
+    const text = '你好世界测试';
+    const wrapped = wrapText(text, 8); // "你好世界" | "测试"
+    for (let c = 0; c < text.length; c++) {
+      const pos = findCursorInWrappedLines(wrapped, c);
+      const renderedChar = wrapped[pos.line]!.line[pos.col];
+      expect(renderedChar, `cursor=${c} should be '${text[c]}' but got '${renderedChar}'`).toBe(text[c]);
+    }
+  });
+
+  it('cursor at text.length maps to end of last line', () => {
+    const text = '你好世界测试';
+    const wrapped = wrapText(text, 8);
+    const pos = findCursorInWrappedLines(wrapped, text.length);
+    expect(pos.line).toBe(wrapped.length - 1);
+    expect(pos.col).toBe(wrapped[wrapped.length - 1]!.line.length);
+  });
+
+  it('down arrow from any position on line 0 lands on line 1', () => {
+    const text = '你好世界测试文字十个'; // 10 CJK chars
+    const wrapped = wrapText(text, 8); // 4 | 4 | 2
+    expect(wrapped.length).toBe(3);
+    // From every position on line 0, pressing down should land on line 1
+    for (let col = 0; col < wrapped[0]!.line.length; col++) {
+      // Compute absolute cursor for this position on line 0
+      const absCursor = col;
+      const pos = findCursorInWrappedLines(wrapped, absCursor);
+      expect(pos.line).toBe(0);
+      // Simulate down arrow
+      const targetLine = 1;
+      let absolutePos = wrapped[0]!.line.length + wrapped[0]!.gapSize;
+      // Cap targetCol for forced-break target lines
+      let targetCol = col;
+      if (wrapped[targetLine]!.gapSize === 0 && targetLine < wrapped.length - 1) {
+        targetCol = Math.min(targetCol, wrapped[targetLine]!.line.length - 1);
+      }
+      absolutePos += targetCol;
+      const newPos = findCursorInWrappedLines(wrapped, absolutePos);
+      expect(newPos.line, `down from col=${col} should land on line 1`).toBe(1);
+    }
+  });
+
+  it('down+up returns to the same line', () => {
+    const text = '你好世界测试';
+    const wrapped = wrapText(text, 8);
+    const startCursor = 2;
+    // Down
+    const downAbs = wrapped[0]!.line.length + wrapped[0]!.gapSize + Math.min(2, wrapped[1]!.line.length);
+    const downPos = findCursorInWrappedLines(wrapped, Math.min(downAbs, text.length));
+    expect(downPos.line).toBe(1);
+    // Up
+    let upAbs = 0;
+    const upTargetCol = Math.min(downPos.col, wrapped[0]!.line.length - 1); // cap for forced break
+    upAbs += upTargetCol;
+    const upPos = findCursorInWrappedLines(wrapped, upAbs);
+    expect(upPos.line).toBe(0);
+  });
+
+  it('all characters in mixed CJK+ASCII text are reachable', () => {
+    const text = '你好世界abcdefghij测试';
+    const wrapped = wrapText(text, 10);
+    for (let c = 0; c < text.length; c++) {
+      const pos = findCursorInWrappedLines(wrapped, c);
+      const renderedChar = wrapped[pos.line]!.line[pos.col];
+      expect(renderedChar, `cursor=${c} should be '${text[c]}' but got '${renderedChar}'`).toBe(text[c]);
+    }
+  });
+
+  it('space break boundary still works correctly', () => {
+    const text = 'hello world test';
+    const wrapped = wrapText(text, 10);
+    // Every character should be reachable
+    for (let c = 0; c < text.length; c++) {
+      // Skip gap characters (spaces consumed at break points)
+      const pos = findCursorInWrappedLines(wrapped, c);
+      const line = wrapped[pos.line]!.line;
+      if (pos.col < line.length) {
+        // Character is within the line content
+        expect(line[pos.col]).toBe(text[c]);
+      }
+    }
+  });
+
+  it('hard break (newline) boundary works correctly', () => {
+    const text = '你好\n世界';
+    const wrapped = wrapText(text, 20);
+    expect(wrapped.length).toBe(2);
+    // cursor=0 -> '你', cursor=1 -> '好'
+    expect(wrapped[findCursorInWrappedLines(wrapped, 0).line]!.line[findCursorInWrappedLines(wrapped, 0).col]).toBe('你');
+    expect(wrapped[findCursorInWrappedLines(wrapped, 1).line]!.line[findCursorInWrappedLines(wrapped, 1).col]).toBe('好');
+    // cursor=2 -> newline, maps to end of line 0
+    const pos2 = findCursorInWrappedLines(wrapped, 2);
+    expect(pos2.line).toBe(0);
+    expect(pos2.col).toBe(2); // past end, cursor shows as space
+    // cursor=3 -> '世'
+    const pos3 = findCursorInWrappedLines(wrapped, 3);
+    expect(pos3.line).toBe(1);
+    expect(pos3.col).toBe(0);
   });
 });

--- a/__tests__/input.utils.test.ts
+++ b/__tests__/input.utils.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { preprocessPastedContent, wrapText, findCursorInWrappedLines } from '../src/utils/input.js';
+import stringWidth from 'string-width';
 
 describe('input utils: paste sanitation', () => {
   it('removes ANSI and box drawing chars, normalizes newlines', () => {
@@ -75,5 +76,104 @@ describe('input utils: cursor mapping', () => {
     const pos = findCursorInWrappedLines(wrapped, 12);
     expect(pos.line).toBeGreaterThan(0);
     expect(pos.col).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe('input utils: CJK wrapping', () => {
+  it('wraps CJK text using display width (2 columns per char)', () => {
+    // 4 CJK chars = 8 display columns
+    const text = '你好世界';
+    const wrapped = wrapText(text, 6); // 6 columns => fits 3 CJK chars
+    expect(wrapped.length).toBe(2);
+    expect(wrapped[0].line).toBe('你好世');
+    expect(wrapped[1].line).toBe('界');
+  });
+
+  it('wraps mixed ASCII and CJK text correctly', () => {
+    // "ab你好cd" = 2 + 4 + 2 = 8 display columns
+    const text = 'ab你好cd';
+    const wrapped = wrapText(text, 6);
+    expect(wrapped.length).toBe(2);
+    // First line: "ab你好" = 2+4 = 6 columns, fits exactly
+    expect(wrapped[0].line).toBe('ab你好');
+    expect(wrapped[1].line).toBe('cd');
+  });
+
+  it('does not split a CJK char across lines', () => {
+    // With 5 columns of space, only 2 CJK chars (4 cols) fit, not 2.5
+    const text = '你好世';
+    const wrapped = wrapText(text, 5);
+    expect(wrapped.length).toBe(2);
+    expect(wrapped[0].line).toBe('你好');
+    expect(stringWidth(wrapped[0].line)).toBeLessThanOrEqual(5);
+    expect(wrapped[1].line).toBe('世');
+  });
+
+  it('CJK lines never exceed the display width', () => {
+    const text = '这是一段比较长的中文文字用来测试自动换行功能是否正确';
+    const width = 20;
+    const wrapped = wrapText(text, width);
+    for (const wl of wrapped) {
+      expect(stringWidth(wl.line)).toBeLessThanOrEqual(width);
+    }
+    // All characters should be preserved
+    expect(wrapped.map(w => w.line).join('')).toBe(text);
+  });
+
+  it('CJK forced breaks produce gapSize 0', () => {
+    const text = '你好世界测试'; // 6 chars, 12 display cols
+    const wrapped = wrapText(text, 8); // fits 4 CJK chars
+    expect(wrapped.length).toBe(2);
+    // Forced break (no space) should have gapSize 0
+    expect(wrapped[0].gapSize).toBe(0);
+  });
+});
+
+describe('input utils: CJK cursor mapping', () => {
+  it('maps cursor correctly in CJK-only text', () => {
+    const text = '你好世界测试';
+    const wrapped = wrapText(text, 8); // "你好世界" | "测试"
+    // Cursor at char index 2 (after '好') should be on line 0
+    const pos = findCursorInWrappedLines(wrapped, 2);
+    expect(pos.line).toBe(0);
+    expect(pos.col).toBe(2);
+  });
+
+  it('maps cursor at CJK forced break boundary', () => {
+    const text = '你好世界测试';
+    const wrapped = wrapText(text, 8); // "你好世界" (4 chars) | "测试" (2 chars)
+    // gapSize is 0 for forced CJK break, so cursor=4 should be on line 1, col 0
+    const pos = findCursorInWrappedLines(wrapped, 4);
+    expect(pos.line).toBe(0);
+    expect(pos.col).toBe(4);
+    // cursor=4 is at end of line 0 (after '界')
+    // cursor just past the line should go to next line
+    // With gapSize 0, character 4 ('测') starts line 1
+    // But cursor=4 <= 0+4 so it's still on line 0. Cursor 4 on line 0 is at end.
+  });
+
+  it('cursor after CJK forced break maps to start of next line', () => {
+    const text = '你好世界测试';
+    const wrapped = wrapText(text, 8); // "你好世界" | "测试", gapSize=0
+    // With gapSize=0, the 5th character '测' is at absolute position 4
+    // currentPos after line 0: 0 + 4 + 0 = 4
+    // cursor=4 <= 0+4, so line 0, col 4 (end of line)
+    // But we also need cursor=4 to show on line 1 col 0 since char 4 is there
+    // Actually, cursor=4 at col=4 of a 4-char line means "after last char" = end of line 0
+    // The character at index 4 starts on the next line
+    expect(wrapped[0].line.length).toBe(4);
+    expect(wrapped[1].line).toBe('测试');
+  });
+
+  it('maps cursor in mixed ASCII/CJK wrapped text', () => {
+    // "hello 你好世界" = 5+1+8 = 14 display cols
+    const text = 'hello 你好世界';
+    const wrapped = wrapText(text, 10); // "hello" (space break) | "你好世界"
+    expect(wrapped[0].line).toBe('hello');
+    expect(wrapped[0].gapSize).toBe(1); // space consumed
+    // Cursor at 6 = '你' (after "hello " which is 6 chars)
+    const pos = findCursorInWrappedLines(wrapped, 6);
+    expect(pos.line).toBe(1);
+    expect(pos.col).toBe(0);
   });
 });

--- a/src/DmuxApp.tsx
+++ b/src/DmuxApp.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useMemo } from "react"
 import { Box, Text, useApp, useStdout, useInput } from "ink"
+import stringWidth from "string-width"
 import { TmuxService } from "./services/TmuxService.js"
 
 // Hooks
@@ -1207,7 +1208,8 @@ const DmuxApp: React.FC<DmuxAppProps> = ({
   // - Normal mode calculation:
   //   - Base footer: 4 lines (marginTop + logs divider + logs line + keyboard shortcuts)
   //   - Footer tip: +1 line when footer tips are enabled
-  //   - Toast: +2 lines (toast message + marginBottom) if currentToast exists
+  //   - Toast (active): wrapped lines + header + marginBottom
+  //   - Toast (queued, transitioning): header + marginBottom (2 lines)
   //   - Debug info: +1 line if DEBUG_DMUX
   //   - Status line: +1 line if updateAvailable/currentBranch/debugMessage
   //   - Status messages: +1 line per active message
@@ -1228,14 +1230,19 @@ const DmuxApp: React.FC<DmuxAppProps> = ({
       // Add toast notification (calculate wrapped lines + header)
       if (currentToast) {
         // Toast format: "✓ message" - icon (1) + space (1) + message
-        const iconAndSpaceLength = 2;
-        const toastTextLength = iconAndSpaceLength + currentToast.message.length;
+        // Use stringWidth for CJK-aware display width calculation
+        const iconAndSpaceWidth = 2;
+        const toastDisplayWidth = iconAndSpaceWidth + stringWidth(currentToast.message);
 
         // Available width is sidebar width (40) minus padding/margins (~2)
         const availableWidth = SIDEBAR_WIDTH - 2;
-        const wrappedLines = Math.ceil(toastTextLength / availableWidth);
+        const wrappedLines = Math.ceil(toastDisplayWidth / availableWidth);
 
         footerLines += wrappedLines + 1 + 1; // wrapped lines + header line + marginBottom
+      } else if (toastQueueLength > 0) {
+        // When there are queued toasts but no current toast (transition state),
+        // FooterHelp still renders the notification header + marginBottom
+        footerLines += 1 + 1; // header line + marginBottom
       }
 
       // Add debug info

--- a/src/components/inputs/CleanTextInput.tsx
+++ b/src/components/inputs/CleanTextInput.tsx
@@ -315,12 +315,7 @@ const CleanTextInput: React.FC<CleanTextInputProps> = ({
       // Find absolute position of start of current visual line
       let absolutePos = 0;
       for (let i = 0; i < currentPos.line; i++) {
-        absolutePos += wrapped[i].line.length;
-        if (!wrapped[i].isHardBreak && i < wrapped.length - 1) {
-          absolutePos++; // Space between wrapped segments
-        } else if (wrapped[i].isHardBreak) {
-          absolutePos++; // Newline character
-        }
+        absolutePos += wrapped[i]!.line.length + wrapped[i]!.gapSize;
       }
       setCursor(absolutePos);
       return;
@@ -334,15 +329,9 @@ const CleanTextInput: React.FC<CleanTextInputProps> = ({
       // Find absolute position of end of current visual line
       let absolutePos = 0;
       for (let i = 0; i <= currentPos.line; i++) {
-        if (i === currentPos.line) {
-          absolutePos += wrapped[i].line.length;
-        } else {
-          absolutePos += wrapped[i].line.length;
-          if (!wrapped[i].isHardBreak && i < wrapped.length - 1) {
-            absolutePos++; // Space between wrapped segments
-          } else if (wrapped[i].isHardBreak) {
-            absolutePos++; // Newline character
-          }
+        absolutePos += wrapped[i]!.line.length;
+        if (i < currentPos.line) {
+          absolutePos += wrapped[i]!.gapSize;
         }
       }
       setCursor(Math.min(absolutePos, value.length));
@@ -370,38 +359,24 @@ const CleanTextInput: React.FC<CleanTextInputProps> = ({
       if (key.upArrow && currentPos.line > 0) {
         // Move up one visual line
         const targetLine = currentPos.line - 1;
-        const targetCol = Math.min(currentPos.col, wrapped[targetLine].line.length);
+        const targetCol = Math.min(currentPos.col, wrapped[targetLine]!.line.length);
         
         // Convert back to absolute position
         let absolutePos = 0;
         for (let i = 0; i < targetLine; i++) {
-          absolutePos += wrapped[i].line.length;
-          // Add space if this was a soft wrap
-          if (!wrapped[i].isHardBreak && i < wrapped.length - 1) {
-            const nextLineExists = i + 1 < wrapped.length;
-            if (nextLineExists) absolutePos++; // Space between wrapped segments
-          } else if (wrapped[i].isHardBreak) {
-            absolutePos++; // Newline character
-          }
+          absolutePos += wrapped[i]!.line.length + wrapped[i]!.gapSize;
         }
         absolutePos += targetCol;
         setCursor(Math.min(absolutePos, value.length));
       } else if (key.downArrow && currentPos.line < wrapped.length - 1) {
         // Move down one visual line
         const targetLine = currentPos.line + 1;
-        const targetCol = Math.min(currentPos.col, wrapped[targetLine].line.length);
+        const targetCol = Math.min(currentPos.col, wrapped[targetLine]!.line.length);
         
         // Convert back to absolute position
         let absolutePos = 0;
         for (let i = 0; i < targetLine; i++) {
-          absolutePos += wrapped[i].line.length;
-          // Add space if this was a soft wrap
-          if (!wrapped[i].isHardBreak && i < wrapped.length - 1) {
-            const nextLineExists = i + 1 < wrapped.length;
-            if (nextLineExists) absolutePos++; // Space between wrapped segments
-          } else if (wrapped[i].isHardBreak) {
-            absolutePos++; // Newline character
-          }
+          absolutePos += wrapped[i]!.line.length + wrapped[i]!.gapSize;
         }
         absolutePos += targetCol;
         setCursor(Math.min(absolutePos, value.length));

--- a/src/components/inputs/CleanTextInput.tsx
+++ b/src/components/inputs/CleanTextInput.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import { Box, Text, useInput, useFocus, useStdout } from 'ink';
-import { wrapText, findCursorInWrappedLines, preprocessPastedContent } from '../../utils/input.js';
+import stringWidth from 'string-width';
+import { wrapText, findCursorInWrappedLines, findCharIndexAtWidth, preprocessPastedContent } from '../../utils/input.js';
 
 interface CleanTextInputProps {
   value: string;
@@ -334,6 +335,13 @@ const CleanTextInput: React.FC<CleanTextInputProps> = ({
           absolutePos += wrapped[i]!.gapSize;
         }
       }
+      // For forced breaks (gapSize=0, not last line), cursor at lineLength
+      // would map to the next line. Stay on the last character instead.
+      const currentWrapped = wrapped[currentPos.line]!;
+      const isLastLine = currentPos.line === wrapped.length - 1;
+      if (currentWrapped.gapSize === 0 && !isLastLine && currentWrapped.line.length > 0) {
+        absolutePos -= 1;
+      }
       setCursor(Math.min(absolutePos, value.length));
       return;
     }
@@ -356,10 +364,20 @@ const CleanTextInput: React.FC<CleanTextInputProps> = ({
       const wrapped = wrapText(value, maxWidth);
       const currentPos = findCursorInWrappedLines(wrapped, cursor);
       
+      // Use display width for column tracking so mixed-width text
+      // (CJK + ASCII) maintains the correct visual column position.
+      const currentVisualCol = stringWidth(wrapped[currentPos.line]!.line.slice(0, currentPos.col));
+      
       if (key.upArrow && currentPos.line > 0) {
         // Move up one visual line
         const targetLine = currentPos.line - 1;
-        const targetCol = Math.min(currentPos.col, wrapped[targetLine]!.line.length);
+        const targetWrapped = wrapped[targetLine]!;
+        let targetCol = findCharIndexAtWidth(targetWrapped.line, currentVisualCol);
+        // Cap for forced-break lines to stay on this line
+        const isTargetLastLine = targetLine === wrapped.length - 1;
+        if (targetWrapped.gapSize === 0 && !isTargetLastLine) {
+          targetCol = Math.min(targetCol, Math.max(0, targetWrapped.line.length - 1));
+        }
         
         // Convert back to absolute position
         let absolutePos = 0;
@@ -371,7 +389,13 @@ const CleanTextInput: React.FC<CleanTextInputProps> = ({
       } else if (key.downArrow && currentPos.line < wrapped.length - 1) {
         // Move down one visual line
         const targetLine = currentPos.line + 1;
-        const targetCol = Math.min(currentPos.col, wrapped[targetLine]!.line.length);
+        const targetWrapped = wrapped[targetLine]!;
+        let targetCol = findCharIndexAtWidth(targetWrapped.line, currentVisualCol);
+        // Cap for forced-break lines to stay on this line
+        const isTargetLastLine = targetLine === wrapped.length - 1;
+        if (targetWrapped.gapSize === 0 && !isTargetLastLine) {
+          targetCol = Math.min(targetCol, Math.max(0, targetWrapped.line.length - 1));
+        }
         
         // Convert back to absolute position
         let absolutePos = 0;

--- a/src/hooks/usePanes.ts
+++ b/src/hooks/usePanes.ts
@@ -100,7 +100,7 @@ export default function usePanes(
           sidebarProjectsRef.current = loadedSidebarProjects;
           setSidebarProjects(loadedSidebarProjects);
           initialLoadComplete.current = true;
-          continue;
+          break; // Exit loop after initial load — pending loads are handled by the next polling/event cycle
         }
 
         // Rebind and filter panes (removes dead shell panes, keeps worktree panes)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1135,11 +1135,11 @@ class Dmux {
       const oldPanesFile = path.join(homeDmuxDir, `${projectIdentifier}-panes.json`);
       const oldSettingsFile = path.join(homeDmuxDir, `${projectIdentifier}-settings.json`);
       const oldUpdateSettingsFile = path.join(homeDmuxDir, 'update-settings.json');
-      
+
       let panes = [];
       let settings = {};
       let updateSettings = {};
-      
+
       // Try to read old panes file
       if (await this.fileExists(oldPanesFile)) {
         try {
@@ -1149,7 +1149,7 @@ class Dmux {
           // Intentionally silent - migration is best-effort
         }
       }
-      
+
       // Try to read old settings file
       if (await this.fileExists(oldSettingsFile)) {
         try {
@@ -1159,7 +1159,7 @@ class Dmux {
           // Intentionally silent - migration is best-effort
         }
       }
-      
+
       // Try to read old update settings file
       if (await this.fileExists(oldUpdateSettingsFile)) {
         try {
@@ -1169,7 +1169,7 @@ class Dmux {
           // Intentionally silent - migration is best-effort
         }
       }
-      
+
       // Check for config from previous parent directory location
       if (await this.fileExists(oldParentConfigFile)) {
         try {

--- a/src/services/DmuxFocusService.ts
+++ b/src/services/DmuxFocusService.ts
@@ -480,18 +480,24 @@ async function ensureHelperBundle(
       })
     );
 
-    const result = spawnSync('swiftc', [
-      '-O',
-      paths.sourcePath,
-      '-o',
-      tempExecutablePath,
-      '-framework',
-      'AppKit',
-      '-framework',
-      'ApplicationServices',
-    ], {
-      stdio: 'pipe',
-      encoding: 'utf-8',
+    const result = await new Promise<{ status: number | null; stderr: string }>((resolve) => {
+      const child = spawn('swiftc', [
+        '-O',
+        paths.sourcePath,
+        '-o',
+        tempExecutablePath,
+        '-framework',
+        'AppKit',
+        '-framework',
+        'ApplicationServices',
+      ], {
+        stdio: ['ignore', 'ignore', 'pipe'],
+      });
+
+      let stderr = '';
+      child.stderr.on('data', (chunk: Buffer) => { stderr += chunk.toString('utf-8'); });
+      child.on('close', (code) => { resolve({ status: code, stderr }); });
+      child.on('error', () => { resolve({ status: 1, stderr }); });
     });
 
     if (result.status !== 0) {

--- a/src/utils/input.ts
+++ b/src/utils/input.ts
@@ -1,3 +1,20 @@
+import stringWidth from 'string-width';
+
+// Get the display width of a single character (CJK = 2, ASCII = 1, etc.)
+const charDisplayWidth = (char: string): number => stringWidth(char);
+
+// Find the character index where cumulative display width would exceed targetWidth.
+// Returns the number of characters that fit within targetWidth columns.
+const findCharIndexAtWidth = (str: string, targetWidth: number): number => {
+  let width = 0;
+  for (let i = 0; i < str.length; i++) {
+    const cw = charDisplayWidth(str[i]!);
+    if (width + cw > targetWidth) return i;
+    width += cw;
+  }
+  return str.length;
+};
+
 export const preprocessPastedContent = (input: string): string => {
   let cleaned = input.replace(/\x1b\[[0-9;]*m/g, '');
   cleaned = cleaned.replace(/\x1b\[[\d;]*[A-Za-z]/g, '');
@@ -31,34 +48,46 @@ export const preprocessPastedContent = (input: string): string => {
   return unwrappedLines.join('\n');
 };
 
-export const wrapText = (text: string, width: number): { line: string; isHardBreak: boolean }[] => {
-  if (!text) return [{ line: '', isHardBreak: false }];
+export interface WrappedLine {
+  line: string;
+  isHardBreak: boolean;
+  /** Number of characters consumed at the break that don't belong to either line (0 or 1). */
+  gapSize: number;
+}
+
+export const wrapText = (text: string, width: number): WrappedLine[] => {
+  if (!text) return [{ line: '', isHardBreak: false, gapSize: 0 }];
   const hardLines = text.split('\n');
-  const wrappedLines: { line: string; isHardBreak: boolean }[] = [];
+  const wrappedLines: WrappedLine[] = [];
   for (let i = 0; i < hardLines.length; i++) {
-    const hardLine = hardLines[i];
+    const hardLine = hardLines[i]!;
     const isLastHardLine = i === hardLines.length - 1;
-    if (hardLine.length <= width) {
-      wrappedLines.push({ line: hardLine, isHardBreak: !isLastHardLine });
+    if (stringWidth(hardLine) <= width) {
+      wrappedLines.push({ line: hardLine, isHardBreak: !isLastHardLine, gapSize: !isLastHardLine ? 1 : 0 });
     } else {
       let remaining = hardLine;
       while (remaining.length > 0) {
-        if (remaining.length <= width) {
-          wrappedLines.push({ line: remaining, isHardBreak: !isLastHardLine });
+        if (stringWidth(remaining) <= width) {
+          wrappedLines.push({ line: remaining, isHardBreak: !isLastHardLine, gapSize: !isLastHardLine ? 1 : 0 });
           break;
         }
-        let breakPoint = width;
-        let lastSpace = remaining.lastIndexOf(' ', width - 1);
-        if (lastSpace > 0) breakPoint = lastSpace;
-        else {
+        // Find how many characters fit within the display width
+        const maxCharIdx = findCharIndexAtWidth(remaining, width);
+        // Try to break at a space within the fitting range
+        let breakPoint = maxCharIdx;
+        const lastSpace = remaining.lastIndexOf(' ', maxCharIdx - 1);
+        if (lastSpace > 0) {
+          breakPoint = lastSpace;
+        } else {
           const firstSpace = remaining.indexOf(' ');
-          if (firstSpace > 0 && firstSpace < width) breakPoint = firstSpace;
-          else breakPoint = Math.min(width, remaining.length);
+          if (firstSpace > 0 && firstSpace < maxCharIdx) breakPoint = firstSpace;
+          else breakPoint = Math.max(1, maxCharIdx); // ensure at least 1 char progress
         }
         const segment = remaining.slice(0, breakPoint);
-        wrappedLines.push({ line: segment.trimEnd(), isHardBreak: false });
         const nextChar = remaining[breakPoint];
-        if (nextChar === ' ') remaining = remaining.slice(breakPoint + 1);
+        const spaceBreak = nextChar === ' ';
+        wrappedLines.push({ line: segment.trimEnd(), isHardBreak: false, gapSize: spaceBreak ? 1 : 0 });
+        if (spaceBreak) remaining = remaining.slice(breakPoint + 1);
         else remaining = remaining.slice(breakPoint);
       }
     }
@@ -67,26 +96,19 @@ export const wrapText = (text: string, width: number): { line: string; isHardBre
 };
 
 export const findCursorInWrappedLines = (
-  wrappedLines: { line: string; isHardBreak: boolean }[],
+  wrappedLines: WrappedLine[],
   absoluteCursor: number
 ) => {
   if (wrappedLines.length === 0) return { line: 0, col: 0 };
   let currentPos = 0;
   for (let lineIndex = 0; lineIndex < wrappedLines.length; lineIndex++) {
-    const wrappedLine = wrappedLines[lineIndex];
+    const wrappedLine = wrappedLines[lineIndex]!;
     const lineLength = wrappedLine.line.length;
     if (absoluteCursor <= currentPos + lineLength) {
       const colInLine = absoluteCursor - currentPos;
       return { line: lineIndex, col: Math.max(0, Math.min(colInLine, lineLength)) };
     }
-    currentPos += lineLength;
-    if (wrappedLine.isHardBreak) {
-      currentPos++;
-      if (absoluteCursor === currentPos - 1) return { line: lineIndex, col: lineLength };
-    } else if (lineIndex < wrappedLines.length - 1) {
-      currentPos++;
-      if (absoluteCursor === currentPos - 1) return { line: lineIndex, col: lineLength };
-    }
+    currentPos += lineLength + wrappedLine.gapSize;
   }
   const lastLine = wrappedLines[wrappedLines.length - 1];
   return { line: wrappedLines.length - 1, col: lastLine ? lastLine.line.length : 0 };

--- a/src/utils/input.ts
+++ b/src/utils/input.ts
@@ -5,7 +5,7 @@ const charDisplayWidth = (char: string): number => stringWidth(char);
 
 // Find the character index where cumulative display width would exceed targetWidth.
 // Returns the number of characters that fit within targetWidth columns.
-const findCharIndexAtWidth = (str: string, targetWidth: number): number => {
+export const findCharIndexAtWidth = (str: string, targetWidth: number): number => {
   let width = 0;
   for (let i = 0; i < str.length; i++) {
     const cw = charDisplayWidth(str[i]!);
@@ -104,7 +104,14 @@ export const findCursorInWrappedLines = (
   for (let lineIndex = 0; lineIndex < wrappedLines.length; lineIndex++) {
     const wrappedLine = wrappedLines[lineIndex]!;
     const lineLength = wrappedLine.line.length;
-    if (absoluteCursor <= currentPos + lineLength) {
+    const isLastLine = lineIndex === wrappedLines.length - 1;
+    // For forced breaks (gapSize=0, not last line), cursor at the boundary
+    // belongs to the NEXT line since no gap character was consumed.
+    // For gap breaks (gapSize>0) or last line, cursor at boundary stays here.
+    const endInclusive = wrappedLine.gapSize > 0 || isLastLine;
+    if (endInclusive
+      ? absoluteCursor <= currentPos + lineLength
+      : absoluteCursor < currentPos + lineLength) {
       const colInLine = absoluteCursor - currentPos;
       return { line: lineIndex, col: Math.max(0, Math.min(colInLine, lineLength)) };
     }


### PR DESCRIPTION
## Summary

Fixes CJK (Chinese/Japanese/Korean) character handling in the text input component and resolves a startup UI freeze caused by synchronous Swift compilation.

Issue #64 

## Problems

1. **CJK text wrapping**: CJK characters occupy 2 terminal columns but `String.length` treats them as 1, causing incorrect line breaks and cursor misalignment in the text input.

2. **Cursor navigation**: Forced line breaks miscalculated visual column positions, and cursor boundary checks used character count instead of display width.

3. **Startup freeze**: `spawnSync('swiftc', ...)` in `DmuxFocusService` blocked the entire Node.js event loop during macOS native helper compilation — stdin never entered raw mode, all timers suspended, keyboard completely unresponsive until compilation finished.

## Changes

### CJK text wrapping & cursor (`d7afd81`, `d488be0`)
- **`src/utils/input.ts`**: Use `stringWidth()` instead of `.length` for display width calculation; fix forced break point boundary logic
- **`src/components/inputs/CleanTextInput.tsx`**: Visual column-based cursor positioning and navigation
- **`__tests__/input.utils.test.ts`**: Comprehensive test coverage for CJK wrapping, forced breaks, and edge cases

### Startup freeze & related fixes (`0f6fac9`)
- **`src/services/DmuxFocusService.ts`**: Replace `spawnSync('swiftc', ...)` with async `spawn` + Promise to unblock the event loop
- **`src/hooks/usePanes.ts`**: Change `continue` → `break` after initial pane load to prevent unnecessary do-while loop re-entry
- **`src/DmuxApp.tsx`**: Fix footer height calculation with `stringWidth` for CJK toast messages; handle toast queue transition state
- **`__tests__/actions/openInEditorAction.test.ts`**: Isolate `EDITOR` env variable in default-editor tests

## Testing

- `pnpm run typecheck` ✅
- `pnpm run test` — passed, but please check again.