### PR TITLE
feat: Added per-project colour themes to help distinguish workspaces

### DIFF
--- a/__tests__/settingsManager.defaults.test.ts
+++ b/__tests__/settingsManager.defaults.test.ts
@@ -27,6 +27,7 @@ describe('SettingsManager defaults', () => {
       maxPaneWidth: 80,
       enabledNotificationSounds: ['default-system-sound'],
       showFooterTips: true,
+      colorTheme: 'orange',
     });
   });
 
@@ -47,6 +48,46 @@ describe('SettingsManager defaults', () => {
 
     manager.updateSetting('showFooterTips', false, 'project');
     expect(manager.getSettings().showFooterTips).toBe(false);
+  });
+
+  it('allows overriding colorTheme with a valid theme name', async () => {
+    vi.mock('fs', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('fs')>();
+      return {
+        ...actual,
+        existsSync: vi.fn(() => false),
+        readFileSync: vi.fn(),
+        writeFileSync: vi.fn(),
+        mkdirSync: vi.fn(),
+      };
+    });
+
+    const { SettingsManager } = await import('../src/utils/settingsManager.js');
+    const manager = new SettingsManager('/tmp/test-project');
+
+    manager.updateSetting('colorTheme', 'cyan', 'project');
+    expect(manager.getSettings().colorTheme).toBe('cyan');
+    expect(manager.getProjectSettings().colorTheme).toBe('cyan');
+  });
+
+  it('rejects invalid colorTheme values', async () => {
+    vi.mock('fs', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('fs')>();
+      return {
+        ...actual,
+        existsSync: vi.fn(() => false),
+        readFileSync: vi.fn(),
+        writeFileSync: vi.fn(),
+        mkdirSync: vi.fn(),
+      };
+    });
+
+    const { SettingsManager } = await import('../src/utils/settingsManager.js');
+    const manager = new SettingsManager('/tmp/test-project');
+
+    expect(() => manager.updateSetting('colorTheme', 'teal' as any, 'global')).toThrow(
+      'Invalid colorTheme'
+    );
   });
 
   it('allows overriding enabledNotificationSounds with valid sound ids', async () => {

--- a/src/DmuxApp.tsx
+++ b/src/DmuxApp.tsx
@@ -86,6 +86,12 @@ import {
   getProjectActionByIndex,
 } from "./utils/projectActions.js"
 import { getPaneProjectRoot } from "./utils/paneProject.js"
+import { normalizeDmuxTheme } from "./theme/themePalette.js"
+import { applyDmuxTheme } from "./theme/colors.js"
+import {
+  applyTmuxThemeToSession,
+  refreshWelcomePaneTheme,
+} from "./utils/welcomePane.js"
 
 const DmuxApp: React.FC<DmuxAppProps> = ({
   panesFile,
@@ -113,7 +119,11 @@ const DmuxApp: React.FC<DmuxAppProps> = ({
   // Settings state
   const [settingsManager] = useState(() => new SettingsManager(projectRoot))
   const { projectSettings, saveSettings } = useProjectSettings(settingsFile)
-  const settings = settingsManager.getSettings()
+  const [themeRefreshNonce, setThemeRefreshNonce] = useState(0)
+  const [settings, setSettings] = useState(() => new SettingsManager(sessionProjectRoot).getSettings())
+  const [selectedThemeName, setSelectedThemeName] = useState(() =>
+    normalizeDmuxTheme(new SettingsManager(sessionProjectRoot).getSettings().colorTheme)
+  )
 
   // Dialog state management
   const dialogState = useDialogState()
@@ -241,7 +251,7 @@ const DmuxApp: React.FC<DmuxAppProps> = ({
   useEffect(() => {
     const checkHooksPreference = async () => {
       // Check if user already has a preference
-      const settings = settingsManager.getSettings()
+      const settings = new SettingsManager(sessionProjectRoot).getSettings()
 
       if (settings.useTmuxHooks !== undefined) {
         // User has already decided
@@ -260,6 +270,7 @@ const DmuxApp: React.FC<DmuxAppProps> = ({
         setUseHooks(true)
         // Save the preference
         settingsManager.updateSetting('useTmuxHooks', true, 'global')
+        refreshDmuxSettings()
       } else {
         // Need to ask user - show prompt
         setShowHooksPrompt(true)
@@ -515,6 +526,17 @@ const DmuxApp: React.FC<DmuxAppProps> = ({
       || sessionProjectRoot
     )
   }, [selectedIndex, panes, projectActionLayout.actionItems, sessionProjectRoot])
+  applyDmuxTheme(selectedThemeName)
+
+  const refreshDmuxSettings = (activeProjectRoot: string = selectedProjectRoot, nextTheme?: string) => {
+    setSettings(new SettingsManager(sessionProjectRoot).getSettings())
+    setSelectedThemeName(
+      nextTheme
+        ? normalizeDmuxTheme(nextTheme)
+        : normalizeDmuxTheme(new SettingsManager(activeProjectRoot).getSettings().colorTheme)
+    )
+    setThemeRefreshNonce((current) => current + 1)
+  }
   const navigationRows = useMemo(
     () => isLoading
       ? projectActionLayout.groups.flatMap((group) =>
@@ -527,6 +549,22 @@ const DmuxApp: React.FC<DmuxAppProps> = ({
     () => isLoading ? [] : buildGroupStartRows(projectActionLayout),
     [isLoading, projectActionLayout]
   )
+
+  useEffect(() => {
+    setSelectedThemeName(
+      normalizeDmuxTheme(new SettingsManager(selectedProjectRoot).getSettings().colorTheme)
+    )
+  }, [selectedProjectRoot])
+
+  useEffect(() => {
+    try {
+      applyTmuxThemeToSession(sessionName, selectedProjectRoot)
+    } catch {
+      // Theme updates are best-effort at runtime.
+    }
+
+    void refreshWelcomePaneTheme(panesFile, selectedProjectRoot)
+  }, [panesFile, selectedProjectRoot, selectedThemeName, sessionName])
 
   useEffect(() => {
     const maxIndex = Math.max(0, projectActionLayout.totalItems - 1)
@@ -1137,17 +1175,20 @@ const DmuxApp: React.FC<DmuxAppProps> = ({
         setShowHooksPrompt(false)
         setUseHooks(true)
         settingsManager.updateSetting('useTmuxHooks', true, 'global')
+        refreshDmuxSettings()
       } else if (input === 'n') {
         // No - use polling
         setShowHooksPrompt(false)
         setUseHooks(false)
         settingsManager.updateSetting('useTmuxHooks', false, 'global')
+        refreshDmuxSettings()
       } else if (key.return) {
         // Select current option
         setShowHooksPrompt(false)
         const selected = hooksPromptIndex === 0
         setUseHooks(selected)
         settingsManager.updateSetting('useTmuxHooks', selected, 'global')
+        refreshDmuxSettings()
       }
     },
     { isActive: showHooksPrompt }
@@ -1178,6 +1219,7 @@ const DmuxApp: React.FC<DmuxAppProps> = ({
     projectSettings,
     saveSettings,
     settingsManager,
+    refreshDmuxSettings,
     popupManager,
     actionSystem,
     controlPaneId,
@@ -1259,13 +1301,14 @@ const DmuxApp: React.FC<DmuxAppProps> = ({
   const contentHeight = Math.max(terminalHeight - footerLines, 10)
 
   return (
-    <Box flexDirection="column" height={terminalHeight}>
+    <Box key={`theme-${selectedThemeName}-${themeRefreshNonce}`} flexDirection="column" height={terminalHeight}>
       {/* Main content area - height dynamically adjusts for status messages */}
       <Box flexDirection="column" height={contentHeight} overflow="hidden">
         <PanesGrid
           panes={panes}
           selectedIndex={selectedIndex}
           isLoading={isLoading}
+          themeName={selectedThemeName}
           agentStatuses={agentStatuses}
           activeDevSourcePath={activeDevSourcePath}
           sidebarProjects={sidebarProjects}

--- a/src/components/panes/PaneCard.tsx
+++ b/src/components/panes/PaneCard.tsx
@@ -10,6 +10,7 @@ interface PaneCardProps {
   pane: DmuxPane;
   isDevSource: boolean;
   selected: boolean;
+  themeName: string;
 }
 
 const ROW_WIDTH = 40;
@@ -128,7 +129,8 @@ const PaneCard: React.FC<PaneCardProps> = memo(({ pane, isDevSource, selected })
     prevProps.pane.shellType === nextProps.pane.shellType &&
     prevProps.pane.agent === nextProps.pane.agent &&
     prevProps.isDevSource === nextProps.isDevSource &&
-    prevProps.selected === nextProps.selected
+    prevProps.selected === nextProps.selected &&
+    prevProps.themeName === nextProps.themeName
   );
 });
 

--- a/src/components/panes/PanesGrid.tsx
+++ b/src/components/panes/PanesGrid.tsx
@@ -16,6 +16,7 @@ interface PanesGridProps {
   panes: DmuxPane[]
   selectedIndex: number
   isLoading: boolean
+  themeName: string
   agentStatuses?: AgentStatusMap
   activeDevSourcePath?: string
   sidebarProjects: SidebarProject[]
@@ -31,6 +32,7 @@ const PanesGrid: React.FC<PanesGridProps> = memo(({
   panes,
   selectedIndex,
   isLoading,
+  themeName,
   agentStatuses,
   activeDevSourcePath,
   sidebarProjects,
@@ -179,7 +181,7 @@ const PanesGrid: React.FC<PanesGridProps> = memo(({
                 pane={paneWithStatus}
                 isDevSource={isDevSource}
                 selected={isSelected}
-
+                themeName={themeName}
               />
             )
           })}

--- a/src/components/popups/config.ts
+++ b/src/components/popups/config.ts
@@ -7,16 +7,16 @@ import { COLORS, TMUX_COLORS } from '../../theme/colors.js';
 export const POPUP_CONFIG = {
   // Visual theme
   borderStyle: 'round' as const,
-  borderColor: COLORS.accent,          // Orange border for main containers
+  get borderColor() { return COLORS.accent; },
   inputBorderStyle: 'bold' as const,
-  inputBorderColor: COLORS.accent,     // Orange border for input boxes
-  titleColor: COLORS.accent,           // Orange titles
-  successColor: COLORS.success,        // Green for success states
-  errorColor: COLORS.error,            // Red for error states
+  get inputBorderColor() { return COLORS.accent; },
+  get titleColor() { return COLORS.accent; },
+  get successColor() { return COLORS.success; },
+  get errorColor() { return COLORS.error; },
   dimColor: 'gray' as const,           // Gray for hints/secondary text
 
   // Tmux popup styling (used in popup.ts) - foreground only
-  tmuxBorderColor: TMUX_COLORS.activeBorder,    // colour214
+  get tmuxBorderColor() { return TMUX_COLORS.activeBorder; },
 
   // Default dimensions
   defaultWidth: 60,

--- a/src/components/popups/settingsPopup.tsx
+++ b/src/components/popups/settingsPopup.tsx
@@ -39,6 +39,17 @@ interface PendingSettingUpdate {
   scope: 'global' | 'project';
 }
 
+const THEME_PREVIEW_COLORS: Record<string, string> = {
+  red: '#ff5f5f',
+  blue: '#5f87ff',
+  yellow: '#ffd75f',
+  orange: '#ff8700',
+  green: '#5fd75f',
+  purple: '#af87ff',
+  cyan: '#5fd7d7',
+  magenta: '#ff5fd7',
+};
+
 const SettingsPopupApp: React.FC<SettingsPopupProps> = ({
   resultFile,
   settingDefinitions,
@@ -69,6 +80,18 @@ const SettingsPopupApp: React.FC<SettingsPopupProps> = ({
   const currentDef = editingKey ? settingDefinitions.find(d => d.key === editingKey) : null;
 
   const isTextEditing = mode === 'edit' && currentDef?.type === 'text';
+
+  const getOptionColor = (definition: SettingDefinition, optionValue: string, isSelected: boolean): string => {
+    if (!isSelected) {
+      return 'white';
+    }
+
+    if (definition.key === 'colorTheme') {
+      return THEME_PREVIEW_COLORS[optionValue] || POPUP_CONFIG.titleColor;
+    }
+
+    return POPUP_CONFIG.titleColor;
+  };
 
   const getNumberBounds = (definition: SettingDefinition): { min: number; max: number } => {
     let min = definition.min ?? Number.MIN_SAFE_INTEGER;
@@ -598,7 +621,10 @@ const SettingsPopupApp: React.FC<SettingsPopupProps> = ({
             <>
               {currentDef.options.map((option, index) => (
                 <Box key={option.value}>
-                  <Text color={editingValueIndex === index ? POPUP_CONFIG.titleColor : 'white'} bold={editingValueIndex === index}>
+                  <Text
+                    color={getOptionColor(currentDef, option.value, editingValueIndex === index)}
+                    bold={editingValueIndex === index}
+                  >
                     {editingValueIndex === index ? '▶ ' : '  '}{option.label}
                   </Text>
                 </Box>

--- a/src/hooks/useInputHandling.ts
+++ b/src/hooks/useInputHandling.ts
@@ -50,6 +50,7 @@ import {
   getCurrentTmuxSessionName,
   type RemotePaneActionShortcut,
 } from "../utils/remotePaneActions.js"
+import { SettingsManager } from "../utils/settingsManager.js"
 
 // Type for the action system returned by useActionSystem hook
 interface ActionSystem {
@@ -90,6 +91,7 @@ interface UseInputHandlingParams {
   projectSettings: any
   saveSettings: (settings: any) => Promise<void>
   settingsManager: any
+  refreshDmuxSettings: (projectRoot?: string, nextTheme?: string) => void
 
   // Services
   popupManager: PopupManager
@@ -155,6 +157,7 @@ export function useInputHandling(params: UseInputHandlingParams) {
     projectSettings,
     saveSettings,
     settingsManager,
+    refreshDmuxSettings,
     popupManager,
     actionSystem,
     controlPaneId,
@@ -1260,6 +1263,8 @@ export function useInputHandling(params: UseInputHandlingParams) {
       }, getActiveProjectRoot())
       if (result) {
         try {
+          const activeProjectRoot = getActiveProjectRoot()
+          const projectSettingsManager = new SettingsManager(activeProjectRoot)
           const updates = Array.isArray((result as any).updates)
             ? (result as any).updates
             : [result]
@@ -1277,10 +1282,16 @@ export function useInputHandling(params: UseInputHandlingParams) {
               continue
             }
 
-            settingsManager.updateSetting(
+            projectSettingsManager.updateSetting(
               update.key as keyof import("../types.js").DmuxSettings,
               update.value,
               update.scope
+            )
+            refreshDmuxSettings(
+              activeProjectRoot,
+              update.key === "colorTheme" && typeof update.value === "string"
+                ? update.value
+                : undefined
             )
             savedCount += 1
             lastScope = update.scope

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,8 +17,11 @@ import { AutoUpdater } from './services/AutoUpdater.js';
 import { StateManager } from './shared/StateManager.js';
 import { LogService } from './services/LogService.js';
 import { TmuxService } from './services/TmuxService.js';
-import { createWelcomePane, destroyWelcomePane } from './utils/welcomePane.js';
-import { TMUX_COLORS } from './theme/colors.js';
+import {
+  applyTmuxThemeToSession,
+  createWelcomePane,
+  destroyWelcomePane,
+} from './utils/welcomePane.js';
 import { SIDEBAR_WIDTH } from './utils/layoutManager.js';
 import { validateSystemRequirements, printValidationResults } from './utils/systemCheck.js';
 import { getUntrackedPanes } from './utils/shellPaneDetection.js';
@@ -1257,12 +1260,11 @@ class Dmux {
   private applySessionPaneBorderOptions(sessionName: string, stdio: 'pipe' | 'inherit' = 'pipe') {
     const sessionOptions = [
       `set-option -t ${sessionName} pane-border-status top`,
-      `set-option -t ${sessionName} pane-active-border-style "fg=colour${TMUX_COLORS.activeBorder}"`,
-      `set-option -t ${sessionName} pane-border-style "fg=colour${TMUX_COLORS.inactiveBorder}"`,
       `set-option -t ${sessionName} pane-border-format " #{?@dmux_attention,#[bold]![ready] #[default],}${TMUX_PANE_TITLE_DISPLAY_FORMAT} "`,
     ].join(' \\; ');
 
     execSync(`tmux ${sessionOptions}`, { stdio });
+    applyTmuxThemeToSession(sessionName, this.projectRoot);
   }
 
   private setupResizeHook(sessionName: string = this.sessionName) {

--- a/src/panes/decorative-pane.ts
+++ b/src/panes/decorative-pane.ts
@@ -4,30 +4,21 @@
 // This runs continuously without showing a command prompt
 
 import { ASCII_ART as ASCII_ART_EXPORTS } from "../utils/asciiArt.js"
+import { DECORATIVE_THEME, syncDmuxThemeFromSettings } from "../theme/colors.js"
 
 // Parse the ASCII art string into an array of lines
 const ASCII_ART = ASCII_ART_EXPORTS.dmuxWelcome.trim().split("\n")
 
 const FILL_CHAR = "·"
-const ORANGE = "\x1b[38;5;208m" // ANSI 256-color orange
-const DIM_GRAY = "\x1b[38;5;238m" // Dim gray for fill dots
-const RESET = "\x1b[0m" // Reset color
+syncDmuxThemeFromSettings(process.cwd())
+const DIM_GRAY = DECORATIVE_THEME.fill
+const RESET = DECORATIVE_THEME.reset
 
 // Static drop settings
 const TAIL_LENGTH = 8 // Length of the fading tail
 const NUM_STATIC_DROPS = 150 // Number of drops to render in static view
 
-// Shades from bright to dim for the tail effect (orange)
-const SHADES = [
-  "\x1b[38;5;214m", // Bright orange
-  "\x1b[38;5;208m", // Orange
-  "\x1b[38;5;202m", // Darker orange
-  "\x1b[38;5;166m", // Even darker
-  "\x1b[38;5;130m", // Very dark orange
-  "\x1b[38;5;94m", // Brown-orange
-  "\x1b[38;5;58m", // Dark brown
-  "\x1b[38;5;236m", // Almost black
-]
+const SHADES = DECORATIVE_THEME.tail
 
 interface GridCell {
   char: string
@@ -133,7 +124,7 @@ function render(width: number, height: number): void {
         if (artCol >= 0 && artCol < trimmedArt.length) {
           const artChar = trimmedArt[artCol]
           // ASCII art takes precedence - render in orange
-          line += ORANGE + artChar + RESET
+          line += DECORATIVE_THEME.primary + artChar + RESET
         } else {
           // Outside art region - show background or fill char
           const bg = backgroundGrid[row][col]

--- a/src/services/PopupManager.ts
+++ b/src/services/PopupManager.ts
@@ -28,6 +28,7 @@ import { resolveDistPath } from "../utils/runtimePaths.js"
 import { getPaneProjectRoot } from "../utils/paneProject.js"
 import { getPaneDisplayName } from "../utils/paneTitle.js"
 import type { TrackProjectActivity } from "../types/activity.js"
+import { SettingsManager } from "../utils/settingsManager.js"
 import type {
   ReopenWorktreePopupResult,
   ReopenWorktreePopupState,
@@ -216,6 +217,7 @@ export class PopupManager {
         const popupOptions: TmuxPopupOptions = {
           ...positioning,
           title: options.title,
+          cwd: projectRoot || this.config.projectRoot,
         }
 
         if (positioning.width !== undefined || options.width !== undefined) {
@@ -604,6 +606,8 @@ export class PopupManager {
     if (!this.checkPopupSupport()) return null
 
     try {
+      const resolvedProjectRoot = projectRoot || this.config.projectRoot
+      const settingsManager = new SettingsManager(resolvedProjectRoot)
       let settingsPopupWidth = 84
       try {
         // Use tmux client dimensions, not the dmux pane's stdout width.
@@ -624,13 +628,13 @@ export class PopupManager {
         },
         {
           settingDefinitions: SETTING_DEFINITIONS,
-          settings: this.config.settingsManager.getSettings(),
-          globalSettings: this.config.settingsManager.getGlobalSettings(),
-          projectSettings: this.config.settingsManager.getProjectSettings(),
-          projectRoot: this.config.projectRoot,
+          settings: settingsManager.getSettings(),
+          globalSettings: settingsManager.getGlobalSettings(),
+          projectSettings: settingsManager.getProjectSettings(),
+          projectRoot: resolvedProjectRoot,
           controlPaneId: this.config.controlPaneId,
         },
-        projectRoot
+        resolvedProjectRoot
       )
 
       if (result.success) {

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -1,39 +1,142 @@
-/**
- * Global color theme for dmux
- * These colors are used consistently across the TUI
- */
+import { SettingsManager } from '../utils/settingsManager.js';
+import type { DmuxThemeName } from '../types.js';
+import {
+  DEFAULT_DMUX_THEME,
+  isDmuxThemeName,
+  normalizeDmuxTheme,
+} from './themePalette.js';
 
-// ANSI 256-color code 208 - matches the decorative welcome pane
-export const DMUX_ORANGE = '#ff8700';
+interface ThemePalette {
+  accentHex: string;
+  activeBorder: string;
+  artPrimary: string;
+  artTail: string[];
+}
 
-// Lighter orange for tmux borders (ANSI 256-color code 214)
-export const DMUX_ORANGE_LIGHT = '#ffaf00';
+const THEME_PALETTES: Record<DmuxThemeName, ThemePalette> = {
+  red: {
+    accentHex: '#ff5f5f',
+    activeBorder: '203',
+    artPrimary: '\x1b[38;5;203m',
+    artTail: ['\x1b[38;5;210m', '\x1b[38;5;203m', '\x1b[38;5;196m', '\x1b[38;5;160m', '\x1b[38;5;124m', '\x1b[38;5;88m', '\x1b[38;5;52m', '\x1b[38;5;236m'],
+  },
+  blue: {
+    accentHex: '#5f87ff',
+    activeBorder: '75',
+    artPrimary: '\x1b[38;5;75m',
+    artTail: ['\x1b[38;5;117m', '\x1b[38;5;75m', '\x1b[38;5;69m', '\x1b[38;5;33m', '\x1b[38;5;27m', '\x1b[38;5;25m', '\x1b[38;5;18m', '\x1b[38;5;236m'],
+  },
+  yellow: {
+    accentHex: '#ffd75f',
+    activeBorder: '221',
+    artPrimary: '\x1b[38;5;221m',
+    artTail: ['\x1b[38;5;227m', '\x1b[38;5;221m', '\x1b[38;5;220m', '\x1b[38;5;214m', '\x1b[38;5;178m', '\x1b[38;5;142m', '\x1b[38;5;100m', '\x1b[38;5;236m'],
+  },
+  orange: {
+    accentHex: '#ff8700',
+    activeBorder: '214',
+    artPrimary: '\x1b[38;5;208m',
+    artTail: ['\x1b[38;5;214m', '\x1b[38;5;208m', '\x1b[38;5;202m', '\x1b[38;5;166m', '\x1b[38;5;130m', '\x1b[38;5;94m', '\x1b[38;5;58m', '\x1b[38;5;236m'],
+  },
+  green: {
+    accentHex: '#5fd75f',
+    activeBorder: '77',
+    artPrimary: '\x1b[38;5;77m',
+    artTail: ['\x1b[38;5;120m', '\x1b[38;5;77m', '\x1b[38;5;70m', '\x1b[38;5;40m', '\x1b[38;5;34m', '\x1b[38;5;28m', '\x1b[38;5;22m', '\x1b[38;5;236m'],
+  },
+  purple: {
+    accentHex: '#af87ff',
+    activeBorder: '141',
+    artPrimary: '\x1b[38;5;141m',
+    artTail: ['\x1b[38;5;183m', '\x1b[38;5;141m', '\x1b[38;5;135m', '\x1b[38;5;99m', '\x1b[38;5;93m', '\x1b[38;5;57m', '\x1b[38;5;55m', '\x1b[38;5;236m'],
+  },
+  cyan: {
+    accentHex: '#5fd7d7',
+    activeBorder: '80',
+    artPrimary: '\x1b[38;5;80m',
+    artTail: ['\x1b[38;5;123m', '\x1b[38;5;80m', '\x1b[38;5;44m', '\x1b[38;5;37m', '\x1b[38;5;31m', '\x1b[38;5;24m', '\x1b[38;5;23m', '\x1b[38;5;236m'],
+  },
+  magenta: {
+    accentHex: '#ff5fd7',
+    activeBorder: '206',
+    artPrimary: '\x1b[38;5;206m',
+    artTail: ['\x1b[38;5;213m', '\x1b[38;5;206m', '\x1b[38;5;199m', '\x1b[38;5;163m', '\x1b[38;5;127m', '\x1b[38;5;90m', '\x1b[38;5;53m', '\x1b[38;5;236m'],
+  },
+};
+
+function assignMutableRecord<T extends Record<string, string>>(target: T, source: T): void {
+  for (const [key, value] of Object.entries(source)) {
+    target[key as keyof T] = value as T[keyof T];
+  }
+}
 
 export const COLORS = {
-  // Primary accent color (orange from welcome pane)
-  accent: DMUX_ORANGE,
-
-  // UI colors
-  selected: DMUX_ORANGE,
+  accent: '',
+  selected: '',
   unselected: 'white',
   border: 'gray',
-  borderSelected: DMUX_ORANGE,
-
-  // Status colors
+  borderSelected: '',
   success: 'green',
   error: 'red',
   warning: 'yellow',
   info: 'cyan',
-
-  // Agent status colors
   working: 'cyan',
   analyzing: 'magenta',
   waiting: 'yellow',
+} as const satisfies Record<string, string>;
+
+export const TMUX_COLORS = {
+  activeBorder: '',
+  inactiveBorder: '240',
+} as const satisfies Record<string, string>;
+
+export const DECORATIVE_THEME = {
+  primary: '',
+  fill: '\x1b[38;5;238m',
+  reset: '\x1b[0m',
+  tail: Array.from({ length: 8 }, () => ''),
 } as const;
 
-// Tmux-specific colors (for use in tmux commands)
-// Only foreground colors - respects user's terminal background settings
-export const TMUX_COLORS = {
-  activeBorder: '214',  // Light orange (ANSI 256-color)
-  inactiveBorder: '240', // Gray (ANSI 256-color)
-} as const;
+let activeThemeName: DmuxThemeName = DEFAULT_DMUX_THEME;
+
+export function applyDmuxTheme(themeName: DmuxThemeName): DmuxThemeName {
+  const nextTheme = THEME_PALETTES[themeName];
+  activeThemeName = themeName;
+
+  assignMutableRecord(COLORS as unknown as Record<string, string>, {
+    ...COLORS,
+    accent: nextTheme.accentHex,
+    selected: nextTheme.accentHex,
+    borderSelected: nextTheme.accentHex,
+  });
+
+  assignMutableRecord(TMUX_COLORS as unknown as Record<string, string>, {
+    ...TMUX_COLORS,
+    activeBorder: nextTheme.activeBorder,
+  });
+
+  (DECORATIVE_THEME as { primary: string }).primary = nextTheme.artPrimary;
+  (DECORATIVE_THEME as { tail: string[] }).tail = [...nextTheme.artTail];
+
+  return activeThemeName;
+}
+
+export function getActiveDmuxTheme(): DmuxThemeName {
+  return activeThemeName;
+}
+
+export function syncDmuxThemeFromSettings(projectRoot?: string): DmuxThemeName {
+  try {
+    const settings = new SettingsManager(projectRoot || process.cwd()).getSettings();
+    return applyDmuxTheme(normalizeDmuxTheme(settings.colorTheme));
+  } catch {
+    return applyDmuxTheme(DEFAULT_DMUX_THEME);
+  }
+}
+
+// Keep module consumers working without explicit setup.
+if (process.env.DMUX_THEME && isDmuxThemeName(process.env.DMUX_THEME)) {
+  applyDmuxTheme(process.env.DMUX_THEME);
+} else {
+  syncDmuxThemeFromSettings(process.cwd());
+}

--- a/src/theme/themePalette.ts
+++ b/src/theme/themePalette.ts
@@ -1,0 +1,22 @@
+import type { DmuxThemeName } from '../types.js';
+
+export const DMUX_THEME_NAMES = [
+  'red',
+  'blue',
+  'yellow',
+  'orange',
+  'green',
+  'purple',
+  'cyan',
+  'magenta',
+] as const satisfies readonly DmuxThemeName[];
+
+export const DEFAULT_DMUX_THEME: DmuxThemeName = 'orange';
+
+export function isDmuxThemeName(value: unknown): value is DmuxThemeName {
+  return typeof value === 'string' && (DMUX_THEME_NAMES as readonly string[]).includes(value);
+}
+
+export function normalizeDmuxTheme(value: unknown): DmuxThemeName {
+  return isDmuxThemeName(value) ? value : DEFAULT_DMUX_THEME;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,16 @@
 import type { AgentName, PermissionMode } from './utils/agentLaunch.js';
 import type { NotificationSoundId } from './utils/notificationSounds.js';
 
+export type DmuxThemeName =
+  | 'red'
+  | 'blue'
+  | 'yellow'
+  | 'orange'
+  | 'green'
+  | 'purple'
+  | 'cyan'
+  | 'magenta';
+
 // Agent status with new analyzing state
 export type AgentStatus = 'idle' | 'analyzing' | 'waiting' | 'working';
 
@@ -105,6 +115,8 @@ export interface DmuxSettings {
   enabledNotificationSounds?: NotificationSoundId[];
   // Rotate short dmux tips in the footer
   showFooterTips?: boolean;
+  // Accent color theme used across the TUI and welcome pane
+  colorTheme?: DmuxThemeName;
   // Tmux hooks for event-driven updates (low CPU)
   // true = use hooks, false = use polling, undefined = not yet asked
   useTmuxHooks?: boolean;

--- a/src/utils/asciiArt.ts
+++ b/src/utils/asciiArt.ts
@@ -4,6 +4,7 @@ import fs from "fs"
 import path from "path"
 import { fileURLToPath } from "url"
 import { resolveDistPath } from "./runtimePaths.js"
+import { getActiveDmuxTheme } from "../theme/colors.js"
 
 export interface RenderAsciiArtOptions {
   paneId: string
@@ -67,7 +68,10 @@ export async function renderAsciiArt(
   const absolutePath = path.isAbsolute(scriptPath)
     ? scriptPath
     : path.resolve(scriptPath)
-  await tmuxService.sendKeys(paneId, `'node "${absolutePath}"' Enter`)
+  await tmuxService.sendKeys(
+    paneId,
+    `'DMUX_THEME=${getActiveDmuxTheme()} node "${absolutePath}"' Enter`
+  )
   await new Promise((resolve) => setTimeout(resolve, 150))
 }
 

--- a/src/utils/settingsManager.ts
+++ b/src/utils/settingsManager.ts
@@ -24,6 +24,11 @@ import {
   isNotificationSoundId,
   type NotificationSoundId,
 } from './notificationSounds.js';
+import {
+  DEFAULT_DMUX_THEME,
+  DMUX_THEME_NAMES,
+  isDmuxThemeName,
+} from '../theme/themePalette.js';
 
 const GLOBAL_SETTINGS_PATH = join(homedir(), '.dmux.global.json');
 const PERMISSION_MODES = ['', 'plan', 'acceptEdits', 'bypassPermissions'] as const;
@@ -72,6 +77,7 @@ const DEFAULT_SETTINGS: DmuxSettings = {
   enabledAgents: getDefaultEnabledAgents(),
   enabledNotificationSounds: getDefaultNotificationSoundSelection(),
   showFooterTips: true,
+  colorTheme: DEFAULT_DMUX_THEME,
 };
 
 const AGENT_OPTIONS = getAgentDefinitions().map((agent) => ({
@@ -125,6 +131,16 @@ export const SETTING_DEFINITIONS: SettingDefinition[] = [
     label: 'Show Footer Tips',
     description: 'Rotate short dmux tips in the footer. Disable this if you prefer a quieter sidebar.',
     type: 'boolean',
+  },
+  {
+    key: 'colorTheme',
+    label: 'Colour Theme',
+    description: 'Choose the accent colour for the dmux UI and welcome pane',
+    type: 'select',
+    options: DMUX_THEME_NAMES.map((themeName) => ({
+      value: themeName,
+      label: themeName.charAt(0).toUpperCase() + themeName.slice(1),
+    })),
   },
   {
     key: 'useTmuxHooks',
@@ -305,6 +321,9 @@ export class SettingsManager {
     if (key === 'permissionMode' && typeof value === 'string' && !isPermissionMode(value)) {
       throw new Error(`Invalid permissionMode: "${value}"`);
     }
+    if (key === 'colorTheme' && !isDmuxThemeName(value)) {
+      throw new Error(`Invalid colorTheme: "${String(value)}"`);
+    }
     if (key === 'enabledAgents') {
       if (!Array.isArray(value)) {
         throw new Error('Invalid enabledAgents: expected an array of agent IDs');
@@ -377,6 +396,9 @@ export class SettingsManager {
   updateSettings(settings: Partial<DmuxSettings>, scope: SettingsScope): void {
     if (typeof settings.permissionMode === 'string' && !isPermissionMode(settings.permissionMode)) {
       throw new Error(`Invalid permissionMode: "${settings.permissionMode}"`);
+    }
+    if (settings.colorTheme !== undefined && !isDmuxThemeName(settings.colorTheme)) {
+      throw new Error(`Invalid colorTheme: "${String(settings.colorTheme)}"`);
     }
     if (settings.enabledAgents !== undefined) {
       if (!Array.isArray(settings.enabledAgents)) {

--- a/src/utils/welcomePane.ts
+++ b/src/utils/welcomePane.ts
@@ -1,7 +1,11 @@
 import { renderAsciiArt } from './asciiArt.js';
+import { readFileSync } from 'fs';
 import { LogService } from '../services/LogService.js';
 import { TmuxService } from '../services/TmuxService.js';
 import { SIDEBAR_WIDTH } from './layoutManager.js';
+import type { DmuxConfig } from '../types.js';
+import { syncDmuxThemeFromSettings, TMUX_COLORS } from '../theme/colors.js';
+import { execSync } from 'child_process';
 
 /**
  * Creates a welcome pane in the tmux session
@@ -39,6 +43,7 @@ export async function createWelcomePane(
     await new Promise(resolve => setTimeout(resolve, 300));
 
     // Render the ASCII art in the pane
+    syncDmuxThemeFromSettings(cwd);
     await renderAsciiArt({
       paneId: welcomePaneId,
       art: [], // Uses default from decorative-pane.js
@@ -53,7 +58,6 @@ export async function createWelcomePane(
       const dimensions = await tmuxService.getTerminalDimensions();
 
       // Apply main-vertical layout FIRST (this locks sidebar width)
-      const { execSync } = await import('child_process');
       execSync(`tmux set-window-option main-pane-width ${SIDEBAR_WIDTH}`, { stdio: 'pipe' });
       execSync(`tmux select-layout main-vertical`, { stdio: 'pipe' });
 
@@ -65,7 +69,6 @@ export async function createWelcomePane(
 
     // Switch focus back to the control pane (dmux sidebar)
     try {
-      const { execSync } = await import('child_process');
       execSync(`tmux select-pane -t '${controlPaneId}'`, { stdio: 'pipe' });
     } catch {
       // Ignore if focus switch fails
@@ -119,4 +122,36 @@ export async function welcomePaneExists(welcomePaneId: string | undefined): Prom
 
   const tmuxService = TmuxService.getInstance();
   return await tmuxService.paneExists(welcomePaneId);
+}
+
+export function applyTmuxThemeToSession(sessionName: string, projectRoot?: string): void {
+  syncDmuxThemeFromSettings(projectRoot);
+  execSync(
+    `tmux set-option -t ${sessionName} pane-active-border-style "fg=colour${TMUX_COLORS.activeBorder}"`,
+    { stdio: 'pipe' }
+  );
+  execSync(
+    `tmux set-option -t ${sessionName} pane-border-style "fg=colour${TMUX_COLORS.inactiveBorder}"`,
+    { stdio: 'pipe' }
+  );
+}
+
+export async function refreshWelcomePaneTheme(
+  panesFile: string,
+  projectRoot?: string
+): Promise<void> {
+  try {
+    const config = JSON.parse(readFileSync(panesFile, 'utf8')) as DmuxConfig;
+    if (!config.welcomePaneId) {
+      return;
+    }
+
+    syncDmuxThemeFromSettings(projectRoot);
+    await renderAsciiArt({
+      paneId: config.welcomePaneId,
+      art: [],
+    });
+  } catch {
+    // Best-effort refresh only.
+  }
 }


### PR DESCRIPTION
I was finding it difficult to switch between multiple sessions and not dropping into the wrong one. So I've added in the ability to choose per-project colour themes.

<img width="993" height="507" alt="image" src="https://github.com/user-attachments/assets/9ed744e1-7683-452b-b979-cb8f0eb790c4" />
<img width="989" height="515" alt="image" src="https://github.com/user-attachments/assets/fcfc64a8-3263-493b-96db-867a040cd959" />
<img width="988" height="514" alt="image" src="https://github.com/user-attachments/assets/8b942e92-5f73-48a4-9507-a5d2f7852d46" />

This comes with a new setting in the settings panel
<img width="508" height="279" alt="image" src="https://github.com/user-attachments/assets/67dfeb95-e409-48fe-a336-517211d3b6ae" />