### PR TITLE
fix: run before_worktree_remove hook synchronously (#63)

### DIFF
--- a/__tests__/actions/closeAction.test.ts
+++ b/__tests__/actions/closeAction.test.ts
@@ -338,6 +338,39 @@ describe('closeAction', () => {
       expect(triggerHookSync).toHaveBeenCalledWith('before_worktree_remove', expect.anything(), mockPane);
     });
 
+    // Regression test for https://github.com/standardagents/dmux/issues/63
+    // before_worktree_remove must block until the hook finishes, otherwise the
+    // worktree directory is deleted while the hook is still running.
+    it('should wait for before_worktree_remove hook to finish before enqueueing worktree cleanup', async () => {
+      const mockPane = createWorktreePane();
+      const mockContext = createMockContext([mockPane]);
+
+      vi.mocked(execSync).mockReturnValue(Buffer.from(''));
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({
+        controlPaneId: '%0',
+      }));
+
+      // Record call ordering. Make the hook resolve on a later microtask so a
+      // fire-and-forget caller would observably enqueue cleanup before the
+      // hook finishes.
+      const order: string[] = [];
+      vi.mocked(triggerHookSync).mockImplementation(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        order.push('hook_done');
+        return { success: true };
+      });
+      mockEnqueueCleanup.mockImplementation(() => {
+        order.push('enqueue_cleanup');
+      });
+
+      const result = await closePane(mockPane, mockContext);
+      await result.onSelect!('kill_and_clean');
+
+      expect(triggerHookSync).toHaveBeenCalledWith('before_worktree_remove', expect.anything(), mockPane);
+      expect(mockEnqueueCleanup).toHaveBeenCalledTimes(1);
+      expect(order).toEqual(['hook_done', 'enqueue_cleanup']);
+    });
+
     it('should NOT delete branch when kill_and_clean selected', async () => {
       const mockPane = createWorktreePane({ slug: 'my-feature' });
       const mockContext = createMockContext([mockPane]);

--- a/__tests__/actions/closeAction.test.ts
+++ b/__tests__/actions/closeAction.test.ts
@@ -91,10 +91,15 @@ describe('closeAction', () => {
       const mockPane = createShellPane({ paneId: '%99' });
       const mockContext = createMockContext([mockPane]);
 
-      // Mock must return the pane ID in list-panes so existence check passes
+      // Mock must return the pane ID before kill and omit it after kill.
+      let paneKilled = false;
       vi.mocked(execSync).mockImplementation((cmd: string) => {
         if (cmd.includes('list-panes')) {
-          return '%99\n'; // Pane exists
+          return paneKilled ? '' : '%99\n';
+        }
+        if (cmd.includes('kill-pane')) {
+          paneKilled = true;
+          return Buffer.from('');
         }
         return Buffer.from('');
       });
@@ -108,11 +113,11 @@ describe('closeAction', () => {
       );
       // Verify kill command was called after existence check passed
       expect(execSync).toHaveBeenCalledWith(
-        expect.stringContaining('tmux send-keys'),
+        expect.stringContaining('tmux kill-pane'),
         expect.anything()
       );
-      expect(execSync).toHaveBeenCalledWith(
-        expect.stringContaining('tmux kill-pane'),
+      expect(execSync).not.toHaveBeenCalledWith(
+        expect.stringContaining('tmux send-keys'),
         expect.anything()
       );
     });
@@ -210,6 +215,29 @@ describe('closeAction', () => {
       expect(onPaneRemoveSpy).toHaveBeenCalledWith('%42');
     });
 
+    it('should not treat pane ID prefixes as an existing pane', async () => {
+      const mockPane = createWorktreePane({ paneId: '%1' });
+      const mockContext = createMockContext([mockPane]);
+
+      vi.mocked(execSync).mockImplementation((cmd: string) => {
+        if (cmd.includes('list-panes')) {
+          return '%10\n';
+        }
+        return Buffer.from('');
+      });
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({
+        controlPaneId: '%0',
+      }));
+
+      const result = await closePane(mockPane, mockContext);
+      await result.onSelect!('kill_only');
+
+      const killCalls = vi.mocked(execSync).mock.calls.filter(([cmd]) =>
+        typeof cmd === 'string' && cmd.includes('tmux kill-pane')
+      );
+      expect(killCalls).toHaveLength(0);
+    });
+
     it('should trigger before_pane_close and pane_closed hooks', async () => {
       const mockPane = createWorktreePane({ slug: 'test' });
       const mockContext = createMockContext([mockPane]);
@@ -266,6 +294,32 @@ describe('closeAction', () => {
           deleteBranch: false,
         })
       );
+    });
+
+    it('should not remove pane state or cleanup worktree when tmux pane survives kill', async () => {
+      const mockPane = createWorktreePane({
+        paneId: '%42',
+        worktreePath: '/test/project/.dmux/worktrees/my-feature',
+      });
+      const mockContext = createMockContext([mockPane]);
+      const savePanesSpy = vi.spyOn(mockContext, 'savePanes');
+
+      vi.mocked(execSync).mockImplementation((cmd: string) => {
+        if (cmd.includes('list-panes')) {
+          return '%42\n%0\n';
+        }
+        return Buffer.from('');
+      });
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({
+        controlPaneId: '%0',
+      }));
+
+      const result = await closePane(mockPane, mockContext);
+      const executeResult = await result.onSelect!('kill_and_clean');
+
+      expectError(executeResult, 'Failed to close pane');
+      expect(savePanesSpy).not.toHaveBeenCalled();
+      expect(mockEnqueueCleanup).not.toHaveBeenCalled();
     });
 
     it('should trigger worktree removal hooks', async () => {

--- a/__tests__/actions/closeAction.test.ts
+++ b/__tests__/actions/closeAction.test.ts
@@ -43,6 +43,7 @@ vi.mock('../../src/shared/StateManager.js', () => ({
 
 vi.mock('../../src/utils/hooks.js', () => ({
   triggerHook: vi.fn().mockResolvedValue(undefined),
+  triggerHookSync: vi.fn().mockResolvedValue({ success: true }),
 }));
 
 vi.mock('../../src/services/LogService.js', () => ({
@@ -65,7 +66,7 @@ vi.mock('fs', () => {
 
 import { execSync } from 'child_process';
 import { StateManager } from '../../src/shared/StateManager.js';
-import { triggerHook } from '../../src/utils/hooks.js';
+import { triggerHook, triggerHookSync } from '../../src/utils/hooks.js';
 import fs from 'fs';
 
 describe('closeAction', () => {
@@ -334,7 +335,7 @@ describe('closeAction', () => {
       const result = await closePane(mockPane, mockContext);
       await result.onSelect!('kill_and_clean');
 
-      expect(triggerHook).toHaveBeenCalledWith('before_worktree_remove', expect.anything(), mockPane);
+      expect(triggerHookSync).toHaveBeenCalledWith('before_worktree_remove', expect.anything(), mockPane);
     });
 
     it('should NOT delete branch when kill_and_clean selected', async () => {

--- a/__tests__/integration/paneLifecycle.test.ts
+++ b/__tests__/integration/paneLifecycle.test.ts
@@ -90,6 +90,7 @@ describe('Pane Lifecycle Integration Tests', () => {
   let tmuxSession: MockTmuxSession;
   let gitRepo: MockGitRepo;
   let createdWorktreePaths: Set<string>;
+  let killedPaneIds: Set<string>;
 
   beforeEach(() => {
     // Reset all mocks
@@ -100,6 +101,7 @@ describe('Pane Lifecycle Integration Tests', () => {
     tmuxSession = createMockTmuxSession('dmux-test', 1);
     gitRepo = createMockGitRepo('main');
     createdWorktreePaths = new Set<string>();
+    killedPaneIds = new Set<string>();
 
     fsMock.existsSync.mockImplementation((target) => {
       const value = String(target);
@@ -132,7 +134,26 @@ describe('Pane Lifecycle Integration Tests', () => {
 
       // Tmux list-panes
       if (cmd.includes('list-panes')) {
-        return returnValue('%0:dmux-control:80x24\n%1:test:80x24');
+        return returnValue(
+          [
+            '%0:dmux-control:80x24',
+            '%1:test:80x24',
+          ]
+            .filter((line) => {
+              const paneId = line.match(/^%\d+/)?.[0];
+              return paneId && !killedPaneIds.has(paneId);
+            })
+            .join('\n')
+        );
+      }
+
+      // Tmux kill-pane
+      if (cmd.includes('kill-pane')) {
+        const paneId = cmd.match(/-t '([^']+)'/)?.[1];
+        if (paneId) {
+          killedPaneIds.add(paneId);
+        }
+        return returnValue('');
       }
 
       // Tmux split-window

--- a/__tests__/integration/paneLifecycle.test.ts
+++ b/__tests__/integration/paneLifecycle.test.ts
@@ -53,6 +53,8 @@ vi.mock('../../src/shared/StateManager.js', () => ({
 // Mock hooks
 vi.mock('../../src/utils/hooks.js', () => ({
   triggerHook: vi.fn(() => Promise.resolve()),
+  triggerHookSync: vi.fn(() => Promise.resolve({ success: true })),
+  initializeHooksDirectory: vi.fn(),
 }));
 
 // Mock LogService
@@ -472,6 +474,133 @@ describe('Pane Lifecycle Integration Tests', () => {
 
       // Should return error or handle gracefully
       expect(result).toBeDefined();
+    });
+  });
+
+  describe('Worktree Setup Failure Handling', () => {
+    // Regression tests for: when worktree preparation fails, the pane must
+    // be torn down and the agent must NOT be launched. Leaving the pane open
+    // at projectRoot would let the agent run against main, which is dangerous.
+
+    const getSendKeysCommands = () =>
+      mockExecSync.mock.calls
+        .map(([cmd]) => (typeof cmd === 'string' ? cmd : ''))
+        .filter((cmd) => cmd.includes('send-keys'));
+
+    const getKillPaneCommands = () =>
+      mockExecSync.mock.calls
+        .map(([cmd]) => (typeof cmd === 'string' ? cmd : ''))
+        .filter((cmd) => cmd.includes('kill-pane'));
+
+    it('kills the pane and throws when the worktree is missing', async () => {
+      const { createPane } = await import('../../src/utils/paneCreation.js');
+
+      // Point at an "existing" worktree path that isn't tracked as created
+      // → fs.existsSync(worktreePath + '/.git') returns false → throws inside
+      // the worktree-creation try/catch before any agent command is sent.
+      const missingWorktreePath = '/test/.dmux/worktrees/does-not-exist';
+
+      await expect(
+        createPane(
+          {
+            prompt: 'fix auth bug',
+            agent: 'claude',
+            projectName: 'test-project',
+            existingPanes: [],
+            existingWorktree: {
+              slug: 'does-not-exist',
+              worktreePath: missingWorktreePath,
+              branchName: 'does-not-exist',
+            },
+          },
+          ['claude']
+        )
+      ).rejects.toThrow(/Failed to create worktree/);
+
+      // Pane must be killed so the user is never dropped at projectRoot
+      // with a live shell.
+      expect(
+        getKillPaneCommands().some((cmd) => cmd.includes('%1'))
+      ).toBe(true);
+
+      // Agent launch command must never reach the pane.
+      const sendKeys = getSendKeysCommands();
+      expect(sendKeys.some((cmd) => cmd.includes('claude'))).toBe(false);
+    });
+
+    it('kills the pane and throws when the worktree_created hook fails', async () => {
+      const { triggerHookSync } = await import('../../src/utils/hooks.js');
+      vi.mocked(triggerHookSync).mockResolvedValueOnce({
+        success: false,
+        error: 'dependency install failed',
+      });
+
+      const { createPane } = await import('../../src/utils/paneCreation.js');
+
+      await expect(
+        createPane(
+          {
+            prompt: 'add dashboard',
+            agent: 'claude',
+            projectName: 'test-project',
+            existingPanes: [],
+          },
+          ['claude']
+        )
+      ).rejects.toThrow(/worktree_created hook failed/);
+
+      // Pane must be killed so the agent cannot run inside a
+      // half-configured worktree.
+      expect(
+        getKillPaneCommands().some((cmd) => cmd.includes('%1'))
+      ).toBe(true);
+
+      // Agent launch command must never reach the pane.
+      const sendKeys = getSendKeysCommands();
+      expect(sendKeys.some((cmd) => cmd.includes('claude'))).toBe(false);
+    });
+
+    it('runs worktree_created hook before launching the agent', async () => {
+      const { triggerHookSync } = await import('../../src/utils/hooks.js');
+      const callOrder: string[] = [];
+
+      vi.mocked(triggerHookSync).mockImplementationOnce(async (hookName) => {
+        callOrder.push(`hook:${hookName}`);
+        return { success: true };
+      });
+
+      // Record when the agent launch command is sent to the pane.
+      const originalImpl = mockExecSync.getMockImplementation();
+      mockExecSync.mockImplementation((command: string, options?: any) => {
+        const cmd = command.toString();
+        if (
+          cmd.includes('send-keys')
+          && cmd.includes('claude')
+          && !cmd.includes('worktree add')
+        ) {
+          callOrder.push('agent-launch');
+        }
+        return originalImpl ? originalImpl(command, options) : '';
+      });
+
+      const { createPane } = await import('../../src/utils/paneCreation.js');
+
+      await createPane(
+        {
+          prompt: 'hook ordering test',
+          agent: 'claude',
+          projectName: 'test-project',
+          existingPanes: [],
+        },
+        ['claude']
+      );
+
+      const hookIdx = callOrder.indexOf('hook:worktree_created');
+      const agentIdx = callOrder.indexOf('agent-launch');
+
+      expect(hookIdx).toBeGreaterThanOrEqual(0);
+      expect(agentIdx).toBeGreaterThanOrEqual(0);
+      expect(hookIdx).toBeLessThan(agentIdx);
     });
   });
 

--- a/__tests__/popupManager.reopenWorktreePopup.test.ts
+++ b/__tests__/popupManager.reopenWorktreePopup.test.ts
@@ -70,6 +70,30 @@ describe('PopupManager launchReopenWorktreePopup', () => {
       '/tmp/project-selected'
     );
   });
+
+  it('enables remote branches by default', async () => {
+    const manager = createPopupManager(['claude', 'codex']) as any;
+    manager.checkPopupSupport = vi.fn(() => true);
+    manager.launchPopup = vi.fn().mockResolvedValue({
+      success: false,
+      cancelled: true,
+    });
+
+    await manager.launchReopenWorktreePopup([], '/tmp/project-selected');
+
+    expect(manager.launchPopup).toHaveBeenCalledWith(
+      'reopenWorktreePopup.js',
+      [],
+      expect.any(Object),
+      expect.objectContaining({
+        initialState: expect.objectContaining({
+          includeRemoteBranches: true,
+          remoteLoaded: false,
+        }),
+      }),
+      '/tmp/project-selected'
+    );
+  });
 });
 
 describe('PopupManager launchSingleAgentChoicePopup', () => {

--- a/__tests__/projectActions.test.ts
+++ b/__tests__/projectActions.test.ts
@@ -3,6 +3,7 @@ import type { DmuxPane, SidebarProject } from '../src/types.js';
 import {
   buildProjectActionLayout,
   buildVisualNavigationRows,
+  resolveSelectionAfterPaneClose,
 } from '../src/utils/projectActions.js';
 
 function pane(id: string, slug: string, projectRoot: string): DmuxPane {
@@ -57,5 +58,53 @@ describe('projectActions', () => {
       [0, 1],
       [2, 3, 4],
     ]);
+  });
+
+  it('selects the next pane down in the same project after closing a pane', () => {
+    const panes: DmuxPane[] = [
+      pane('dmux-1', 'main-pane', '/repo-main'),
+      pane('dmux-2', 'aux-one', '/repo-aux'),
+      pane('dmux-3', 'aux-two', '/repo-aux'),
+      pane('dmux-4', 'main-two', '/repo-main'),
+    ];
+    const sidebarProjects: SidebarProject[] = [
+      { projectRoot: '/repo-main', projectName: 'repo-main' },
+      { projectRoot: '/repo-aux', projectName: 'repo-aux' },
+    ];
+
+    const selection = resolveSelectionAfterPaneClose(
+      panes,
+      '%2',
+      sidebarProjects,
+      '/repo-main',
+      'repo-main'
+    );
+
+    expect(selection?.selectedIndex).toBe(1);
+    expect(selection?.pane?.slug).toBe('aux-two');
+  });
+
+  it('selects the project new-agent action when closing the last pane in that project', () => {
+    const panes: DmuxPane[] = [
+      pane('dmux-1', 'main-pane', '/repo-main'),
+      pane('dmux-2', 'aux-one', '/repo-aux'),
+    ];
+    const sidebarProjects: SidebarProject[] = [
+      { projectRoot: '/repo-main', projectName: 'repo-main' },
+      { projectRoot: '/repo-aux', projectName: 'repo-aux' },
+    ];
+
+    const selection = resolveSelectionAfterPaneClose(
+      panes,
+      '%2',
+      sidebarProjects,
+      '/repo-main',
+      'repo-main'
+    );
+
+    expect(selection?.pane).toBeUndefined();
+    expect(selection?.action?.kind).toBe('new-agent');
+    expect(selection?.action?.projectRoot).toBe('/repo-aux');
+    expect(selection?.selectedIndex).toBe(3);
   });
 });

--- a/__tests__/resumeBranches.test.ts
+++ b/__tests__/resumeBranches.test.ts
@@ -98,7 +98,10 @@ describe('resumeBranches', () => {
     fs.rmSync(rootRepo, { recursive: true, force: true });
   });
 
-  it('dedupes orphaned worktrees with local and remote branches across child repos', async () => {
+  it('fetches remotes before deduping orphaned worktrees with local and remote branches', async () => {
+    let rootRemoteFetched = false;
+    let childRemoteFetched = false;
+
     installGitCommandMock((command: string, options?: { cwd?: string; encoding?: string }) => {
       const cwd = options?.cwd;
       const encoding = options?.encoding;
@@ -144,11 +147,21 @@ describe('resumeBranches', () => {
         return output('child/local-only');
       }
 
+      if (command.includes("'fetch' '--prune' 'origin'")) {
+        if (cwd === rootRepo) {
+          rootRemoteFetched = true;
+        }
+        if (cwd === childRepo) {
+          childRemoteFetched = true;
+        }
+        return output('');
+      }
+
       if (cwd === rootRepo && command.includes("'for-each-ref' '--format=%(refname:short)' 'refs/remotes/origin'")) {
-        return output('origin/feature/reopen-me\norigin/feature/remote-only');
+        return output(rootRemoteFetched ? 'origin/feature/reopen-me\norigin/feature/remote-only' : '');
       }
       if (cwd === childRepo && command.includes("'for-each-ref' '--format=%(refname:short)' 'refs/remotes/origin'")) {
-        return output('origin/feature/remote-only\norigin/child/remote-child-only');
+        return output(childRemoteFetched ? 'origin/feature/remote-only\norigin/child/remote-child-only' : '');
       }
 
       return output('');
@@ -193,6 +206,14 @@ describe('resumeBranches', () => {
         }),
       ])
     );
+    expect(execSyncMock).toHaveBeenCalledWith(
+      expect.stringContaining("'fetch' '--prune' 'origin'"),
+      expect.objectContaining({ cwd: rootRepo, stdio: 'pipe' })
+    );
+    expect(execSyncMock).toHaveBeenCalledWith(
+      expect.stringContaining("'fetch' '--prune' 'origin'"),
+      expect.objectContaining({ cwd: childRepo, stdio: 'pipe' })
+    );
   });
 
   it('skips remote branch scans until remote sources are requested', async () => {
@@ -229,6 +250,9 @@ describe('resumeBranches', () => {
 
       if (command.includes("'for-each-ref' '--format=%(refname:short)' 'refs/remotes/origin'")) {
         throw new Error('remote branches should not be queried');
+      }
+      if (command.includes("'fetch' '--prune' 'origin'")) {
+        throw new Error('remote branches should not be fetched');
       }
 
       return output('');

--- a/__tests__/toastLayout.test.ts
+++ b/__tests__/toastLayout.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { getToastSectionLayout } from '../src/utils/toastLayout.js';
+
+describe('toast layout', () => {
+  it('uses display width when sizing CJK toasts', () => {
+    const layout = getToastSectionLayout(
+      { message: '你好世界你好世界你好世界你好世界你好你' },
+      0,
+      38,
+    );
+
+    expect(layout.toastHeight).toBe(3);
+    expect(layout.footerExtraLines).toBe(4);
+  });
+
+  it('keeps queued-toast transition height in sync', () => {
+    const layout = getToastSectionLayout(null, 2, 38);
+
+    expect(layout.toastHeight).toBe(1);
+    expect(layout.footerExtraLines).toBe(2);
+  });
+
+  it('returns zero height when there are no notifications', () => {
+    const layout = getToastSectionLayout(null, 0, 38);
+
+    expect(layout.toastHeight).toBe(0);
+    expect(layout.footerExtraLines).toBe(0);
+  });
+});

--- a/__tests__/useInputHandling.reopenProjectSelection.test.tsx
+++ b/__tests__/useInputHandling.reopenProjectSelection.test.tsx
@@ -240,7 +240,7 @@ describe('useInputHandling reopen project selection', () => {
       {
         includeWorktrees: true,
         includeLocalBranches: true,
-        includeRemoteBranches: false,
+        includeRemoteBranches: true,
         remoteLoaded: false,
         filterQuery: '',
       },
@@ -314,7 +314,7 @@ describe('useInputHandling reopen project selection', () => {
       {
         includeWorktrees: true,
         includeLocalBranches: true,
-        includeRemoteBranches: false,
+        includeRemoteBranches: true,
         remoteLoaded: false,
         filterQuery: '',
       },

--- a/src/DmuxApp.tsx
+++ b/src/DmuxApp.tsx
@@ -1062,9 +1062,6 @@ const DmuxApp: React.FC<DmuxAppProps> = ({
     projectName,
     defaultProjectRoot: sessionProjectRoot,
     onPaneRemove: async (paneId) => {
-      // Mark pane as closing to prevent race condition with worker
-      await lifecycleManager.beginClose(paneId, 'user requested')
-
       const nextSelection = resolveSelectionAfterPaneClose(
         panes,
         paneId,
@@ -1072,10 +1069,6 @@ const DmuxApp: React.FC<DmuxAppProps> = ({
         sessionProjectRoot,
         projectName
       )
-
-      // Remove from panes list
-      const updatedPanes = panes.filter((p) => p.paneId !== paneId)
-      await savePanes(updatedPanes)
 
       if (nextSelection) {
         setSelectedIndex(nextSelection.selectedIndex)
@@ -1085,9 +1078,6 @@ const DmuxApp: React.FC<DmuxAppProps> = ({
           setSelectedIndex(maxIndex)
         }
       }
-
-      // Mark close as completed (no more lock needed)
-      await lifecycleManager.completeClose(paneId)
 
       const targetPaneId = nextSelection?.pane && !nextSelection.pane.hidden
         ? nextSelection.pane.paneId

--- a/src/DmuxApp.tsx
+++ b/src/DmuxApp.tsx
@@ -69,6 +69,7 @@ import {
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
+const ACTIVE_PANE_SYNC_INTERVAL_MS = 350
 import type {
   DmuxPane,
   DmuxAppProps,
@@ -85,6 +86,7 @@ import {
   buildVisualNavigationRows,
   buildGroupStartRows,
   getProjectActionByIndex,
+  resolveSelectionAfterPaneClose,
 } from "./utils/projectActions.js"
 import { getPaneProjectRoot } from "./utils/paneProject.js"
 import { normalizeDmuxTheme } from "./theme/themePalette.js"
@@ -581,6 +583,57 @@ const DmuxApp: React.FC<DmuxAppProps> = ({
 
   // findCardInDirection provided by useNavigation
 
+  const syncSelectedIndexToFocusedPane = React.useCallback(async (activePaneId?: string | null) => {
+    try {
+      const focusedPaneId = activePaneId ?? await TmuxService.getInstance().getActivePaneId()
+      if (!focusedPaneId || focusedPaneId === controlPaneId) {
+        return
+      }
+
+      const focusedIndex = panes.findIndex((pane) => pane.paneId === focusedPaneId)
+      if (focusedIndex === -1) {
+        return
+      }
+
+      setSelectedIndex((currentIndex) =>
+        currentIndex === focusedIndex ? currentIndex : focusedIndex
+      )
+    } catch {
+      // Focus sync is best-effort; pane lifecycle handling will correct stale IDs.
+    }
+  }, [controlPaneId, panes])
+
+  useEffect(() => {
+    const paneEventService = PaneEventService.getInstance()
+    return paneEventService.onPaneFocusChanged((event) => {
+      void syncSelectedIndexToFocusedPane(event.activePaneId)
+    })
+  }, [syncSelectedIndexToFocusedPane])
+
+  useEffect(() => {
+    if (!process.env.TMUX || panes.length === 0) {
+      return
+    }
+
+    let syncInFlight = false
+    const syncActivePane = () => {
+      if (syncInFlight) {
+        return
+      }
+
+      syncInFlight = true
+      void syncSelectedIndexToFocusedPane().finally(() => {
+        syncInFlight = false
+      })
+    }
+
+    syncActivePane()
+    const interval = setInterval(syncActivePane, ACTIVE_PANE_SYNC_INTERVAL_MS)
+    return () => {
+      clearInterval(interval)
+    }
+  }, [panes.length, syncSelectedIndexToFocusedPane])
+
   // savePanes moved to usePanes
 
   // applySmartLayout moved to utils/tmux
@@ -1012,25 +1065,39 @@ const DmuxApp: React.FC<DmuxAppProps> = ({
       // Mark pane as closing to prevent race condition with worker
       await lifecycleManager.beginClose(paneId, 'user requested')
 
-      // Adjust selectedIndex before removing from list
-      const removedIndex = panes.findIndex((p) => p.paneId === paneId)
-      if (removedIndex >= 0 && selectedIndex >= panes.length - 1) {
-        setSelectedIndex(Math.max(0, panes.length - 2))
-      }
+      const nextSelection = resolveSelectionAfterPaneClose(
+        panes,
+        paneId,
+        sidebarProjects,
+        sessionProjectRoot,
+        projectName
+      )
 
       // Remove from panes list
       const updatedPanes = panes.filter((p) => p.paneId !== paneId)
-      savePanes(updatedPanes)
+      await savePanes(updatedPanes)
+
+      if (nextSelection) {
+        setSelectedIndex(nextSelection.selectedIndex)
+      } else {
+        const maxIndex = Math.max(0, projectActionLayout.totalItems - 2)
+        if (selectedIndex > maxIndex) {
+          setSelectedIndex(maxIndex)
+        }
+      }
 
       // Mark close as completed (no more lock needed)
       await lifecycleManager.completeClose(paneId)
 
-      // Return focus to control pane
-      if (controlPaneId) {
+      const targetPaneId = nextSelection?.pane && !nextSelection.pane.hidden
+        ? nextSelection.pane.paneId
+        : controlPaneId
+
+      if (targetPaneId) {
         try {
-          await TmuxService.getInstance().selectPane(controlPaneId)
+          await TmuxService.getInstance().selectPane(targetPaneId)
         } catch {
-          // Ignore - control pane might not exist
+          // Ignore - the target pane might have closed during cleanup
         }
       }
     },

--- a/src/actions/implementations/closeAction.ts
+++ b/src/actions/implementations/closeAction.ts
@@ -12,13 +12,102 @@ import { PaneLifecycleManager } from '../../services/PaneLifecycleManager.js';
 import { triggerHook } from '../../utils/hooks.js';
 import { LogService } from '../../services/LogService.js';
 import { WorktreeCleanupService } from '../../services/WorktreeCleanupService.js';
-import { TMUX_SPLIT_DELAY } from '../../constants/timing.js';
 import { deriveProjectRootFromWorktreePath, getPaneProjectRoot } from '../../utils/paneProject.js';
 import { cleanupPromptFilesForSlug } from '../../utils/promptStore.js';
-import { getPaneBranchName } from '../../utils/git.js';
 import { buildDevWatchRespawnCommand } from '../../utils/devWatchCommand.js';
 import { isActiveDevSourcePath } from '../../utils/devSource.js';
 import { getPaneDisplayName } from '../../utils/paneTitle.js';
+
+const PANE_KILL_VERIFY_DELAYS_MS = [50, 150, 300];
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function parseTmuxPaneIds(output: string | Buffer): Set<string> {
+  const ids = new Set<string>();
+
+  for (const line of output.toString().split('\n')) {
+    const match = line.trim().match(/^%\d+/);
+    if (match) {
+      ids.add(match[0]);
+    }
+  }
+
+  return ids;
+}
+
+function tmuxPaneExists(paneId: string): boolean {
+  try {
+    const paneList = execSync('tmux list-panes -a -F "#{pane_id}"', {
+      encoding: 'utf-8',
+      stdio: 'pipe',
+      timeout: 5000,
+    });
+    return parseTmuxPaneIds(paneList).has(paneId);
+  } catch {
+    LogService.getInstance().debug(
+      `Could not verify pane ${paneId} exists, treating as already closed`,
+      'paneActions'
+    );
+    return false;
+  }
+}
+
+async function waitForTmuxPaneToClose(paneId: string): Promise<boolean> {
+  if (!tmuxPaneExists(paneId)) {
+    return true;
+  }
+
+  for (const delay of PANE_KILL_VERIFY_DELAYS_MS) {
+    await sleep(delay);
+    if (!tmuxPaneExists(paneId)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+async function killTmuxPaneReliably(pane: DmuxPane): Promise<boolean> {
+  if (!tmuxPaneExists(pane.paneId)) {
+    LogService.getInstance().debug(
+      `Pane ${pane.paneId} already gone, skipping kill`,
+      'paneActions'
+    );
+    return true;
+  }
+
+  try {
+    execSync(`tmux kill-pane -t '${pane.paneId}'`, {
+      stdio: 'pipe',
+      timeout: 5000,
+    });
+  } catch (killError) {
+    if (await waitForTmuxPaneToClose(pane.paneId)) {
+      return true;
+    }
+
+    LogService.getInstance().error(
+      `Error killing pane ${pane.paneId}`,
+      'paneActions',
+      pane.id,
+      killError instanceof Error ? killError : undefined
+    );
+    return false;
+  }
+
+  if (await waitForTmuxPaneToClose(pane.paneId)) {
+    return true;
+  }
+
+  LogService.getInstance().warn(
+    `Pane ${pane.paneId} still exists after kill attempt`,
+    'paneActions',
+    pane.id
+  );
+  return false;
+}
 
 /**
  * Close a pane - presents options for how to close
@@ -143,72 +232,25 @@ async function executeCloseOption(
     try {
       let startedBackgroundCleanup = false;
 
-      // CRITICAL: Remove from config FIRST, before killing tmux pane
-      // This prevents the race condition where polling detects "missing" pane
-      // and recreates it before we finish closing
       const updatedPanes = context.panes.filter(p => p.id !== pane.id);
+
+      // Kill and verify the tmux pane before mutating pane state or deleting
+      // the worktree. Sending C-c first can drop an agent back to a shell if
+      // kill-pane fails, so close the pane directly and treat a surviving pane
+      // as a failed close.
+      const paneClosed = await killTmuxPaneReliably(pane);
+      if (!paneClosed) {
+        return {
+          type: 'error',
+          message: `Failed to close pane "${paneName}"; worktree cleanup was not started`,
+          dismissable: true,
+        };
+      }
+
+      // Remove from config only after tmux confirms the pane is gone. The
+      // lifecycle close marker suppresses recreation while the close is in
+      // progress.
       await context.savePanes(updatedPanes);
-
-      // NOW kill the tmux pane (after config is updated)
-      // CRITICAL FIX: First verify the pane exists before trying to interact with it
-      // This prevents crashes/hangs when operating on stale pane IDs
-      let paneExists = false;
-      try {
-        const paneList = execSync('tmux list-panes -a -F "#{pane_id}"', {
-          encoding: 'utf-8',
-          stdio: 'pipe',
-          timeout: 5000 // 5 second timeout to prevent hangs
-        });
-        paneExists = paneList.includes(pane.paneId);
-      } catch {
-        // Error checking panes - assume it doesn't exist
-        LogService.getInstance().debug(`Could not verify pane ${pane.paneId} exists, treating as already closed`, 'paneActions');
-      }
-
-      if (paneExists) {
-        try {
-          // First, try to kill any running process in the pane (like Claude)
-          try {
-            execSync(`tmux send-keys -t '${pane.paneId}' C-c`, {
-              stdio: 'pipe',
-              timeout: 2000 // 2 second timeout
-            });
-            // Wait a moment for the process to exit
-            await new Promise(resolve => setTimeout(resolve, TMUX_SPLIT_DELAY));
-          } catch {
-            // Process might not be running or pane already gone
-          }
-
-          // Now kill the pane
-          execSync(`tmux kill-pane -t '${pane.paneId}'`, {
-            stdio: 'pipe',
-            timeout: 5000 // 5 second timeout
-          });
-
-          // Verify the pane is actually gone
-          await new Promise(resolve => setTimeout(resolve, 100));
-          try {
-            // Check if pane still exists
-            const updatedPaneList = execSync('tmux list-panes -a -F "#{pane_id}"', {
-              encoding: 'utf-8',
-              stdio: 'pipe',
-              timeout: 5000
-            });
-            if (updatedPaneList.includes(pane.paneId)) {
-              const msg = `Pane ${pane.paneId} still exists after kill attempt`;
-              LogService.getInstance().warn(msg, 'paneActions', pane.id);
-            }
-          } catch {
-            // Error listing panes is fine
-          }
-        } catch (killError) {
-          // Pane might already be dead, which is fine
-          const msg = `Error killing pane ${pane.paneId}`;
-          LogService.getInstance().error(msg, 'paneActions', pane.id, killError instanceof Error ? killError : undefined);
-        }
-      } else {
-        LogService.getInstance().debug(`Pane ${pane.paneId} already gone, skipping kill`, 'paneActions');
-      }
 
       // Best-effort cleanup of any stored prompt files for this pane slug
       // (including leftovers from interrupted launches).
@@ -360,13 +402,13 @@ async function executeCloseOption(
         }
       }
 
-        return {
-          type: 'success',
-          message: startedBackgroundCleanup
+      return {
+        type: 'success',
+        message: startedBackgroundCleanup
           ? `Pane "${paneName}" closed successfully (cleanup running in background)`
           : `Pane "${paneName}" closed successfully`,
-          dismissable: true,
-        };
+        dismissable: true,
+      };
     } finally {
       // CRITICAL: Always resume watcher, even if there was an error
       stateManager.resumeConfigWatcher();

--- a/src/actions/implementations/closeAction.ts
+++ b/src/actions/implementations/closeAction.ts
@@ -258,7 +258,7 @@ async function executeCloseOption(
       }
 
       if (context.onPaneRemove) {
-        context.onPaneRemove(pane.paneId); // Pass tmux pane ID, not dmux ID
+        await context.onPaneRemove(pane.paneId); // Pass tmux pane ID, not dmux ID
       }
 
       // Recalculate layout for remaining panes

--- a/src/actions/implementations/closeAction.ts
+++ b/src/actions/implementations/closeAction.ts
@@ -9,7 +9,7 @@ import type { DmuxPane, DmuxConfig } from '../../types.js';
 import type { ActionResult, ActionContext, ActionOption } from '../types.js';
 import { StateManager } from '../../shared/StateManager.js';
 import { PaneLifecycleManager } from '../../services/PaneLifecycleManager.js';
-import { triggerHook } from '../../utils/hooks.js';
+import { triggerHook, triggerHookSync } from '../../utils/hooks.js';
 import { LogService } from '../../services/LogService.js';
 import { WorktreeCleanupService } from '../../services/WorktreeCleanupService.js';
 import { deriveProjectRootFromWorktreePath, getPaneProjectRoot } from '../../utils/paneProject.js';
@@ -278,8 +278,10 @@ async function executeCloseOption(
         } else {
           const mainRepoPath = deriveProjectRootFromWorktreePath(pane.worktreePath) || paneProjectRoot;
 
-          // Trigger before_worktree_remove hook
-          await triggerHook('before_worktree_remove', paneProjectRoot, pane);
+          // Trigger before_worktree_remove hook synchronously — the hook may need
+          // to read the worktree (e.g. run bundled teardown scripts), and the
+          // worktree directory is about to be deleted.
+          await triggerHookSync('before_worktree_remove', paneProjectRoot, pane);
 
           try {
             WorktreeCleanupService.getInstance().enqueueCleanup({

--- a/src/actions/implementations/mergeAction.ts
+++ b/src/actions/implementations/mergeAction.ts
@@ -132,6 +132,7 @@ async function executeSingleRootMerge(
   const siblingPanes = context.panes.filter(
     p => p.id !== pane.id && p.worktreePath === pane.worktreePath
   );
+  let activeContext = context;
 
   // Helper to kill sibling tmux panes and remove them from config
   const closeSiblings = async () => {
@@ -143,10 +144,14 @@ async function executeSingleRootMerge(
       }
     }
     // Remove siblings from saved panes
-    const withoutSiblings = context.panes.filter(
+    const withoutSiblings = activeContext.panes.filter(
       p => !siblingPanes.some(s => s.id === p.id)
     );
-    await context.savePanes(withoutSiblings);
+    await activeContext.savePanes(withoutSiblings);
+    activeContext = {
+      ...activeContext,
+      panes: withoutSiblings,
+    };
     LogService.getInstance().info(
       `Closed ${siblingPanes.length} sibling pane(s) for merge of ${paneName}`,
       'mergeAction',
@@ -167,7 +172,7 @@ async function executeSingleRootMerge(
         });
         return executeMerge(
           pane,
-          context,
+          activeContext,
           validation.mainBranch,
           mergeTarget.targetRepoPath
         );

--- a/src/actions/types.ts
+++ b/src/actions/types.ts
@@ -85,7 +85,7 @@ export interface ActionContext {
 
   // Optional callbacks for specific actions
   onPaneUpdate?: (pane: DmuxPane) => void;
-  onPaneRemove?: (paneId: string) => void;
+  onPaneRemove?: (paneId: string) => void | Promise<void>;
   onActionResult?: (result: ActionResult) => Promise<void>;
 }
 

--- a/src/components/popups/reopenWorktreePopup.tsx
+++ b/src/components/popups/reopenWorktreePopup.tsx
@@ -564,7 +564,7 @@ function main() {
       initialState={data.initialState ?? {
         includeWorktrees: true,
         includeLocalBranches: true,
-        includeRemoteBranches: false,
+        includeRemoteBranches: true,
         remoteLoaded: false,
         filterQuery: '',
       }}

--- a/src/hooks/useActionSystem.ts
+++ b/src/hooks/useActionSystem.ts
@@ -23,7 +23,7 @@ interface UseActionSystemParams {
   projectName: string;
   defaultProjectRoot: string;
   onPaneUpdate?: (pane: DmuxPane) => void;
-  onPaneRemove?: (paneId: string) => void;
+  onPaneRemove?: (paneId: string) => void | Promise<void>;
   onActionResult?: (result: ActionResult) => Promise<void>;
   trackProjectActivity: TrackProjectActivity;
 

--- a/src/hooks/useInputHandling.ts
+++ b/src/hooks/useInputHandling.ts
@@ -936,7 +936,7 @@ export function useInputHandling(params: UseInputHandlingParams) {
     const popupState = {
       includeWorktrees: true,
       includeLocalBranches: true,
-      includeRemoteBranches: false,
+      includeRemoteBranches: true,
       remoteLoaded: false,
       filterQuery: "",
     }

--- a/src/services/DmuxFocusService.ts
+++ b/src/services/DmuxFocusService.ts
@@ -845,7 +845,7 @@ export class DmuxFocusService extends EventEmitter {
 
     try {
       const [currentPaneId, currentWindowId, paneWindowId] = await Promise.all([
-        this.tmuxService.getCurrentPaneId(),
+        this.tmuxService.getActivePaneId(),
         this.tmuxService.getCurrentWindowId(),
         this.tmuxService.getPaneWindowId(tmuxPaneId),
       ]);
@@ -978,7 +978,7 @@ export class DmuxFocusService extends EventEmitter {
     }
 
     try {
-      const currentPaneId = await this.tmuxService.getCurrentPaneId();
+      const currentPaneId = await this.tmuxService.getActivePaneId();
       if (!currentPaneId) {
         this.setFullyFocusedPaneId(null);
         return;

--- a/src/services/PaneEventService.ts
+++ b/src/services/PaneEventService.ts
@@ -26,6 +26,13 @@ export interface PaneChangeEvent {
   source: PaneEventMode;
 }
 
+export interface PaneFocusEvent {
+  type: 'pane-focus-changed';
+  activePaneId?: string | null;
+  timestamp: number;
+  source: PaneEventMode;
+}
+
 interface PaneEventConfig {
   sessionName: string;
   controlPaneId?: string;
@@ -106,11 +113,17 @@ export class PaneEventService extends EventEmitter {
   private startHookMode(): void {
     // Subscribe to hook events with debouncing
     this.unsubscribeHook = this.hookManager.onHookTriggered(() => {
+      const timestamp = Date.now();
       this.emit('panes-changed', {
         type: 'panes-changed',
-        timestamp: Date.now(),
+        timestamp,
         source: 'hooks',
       } as PaneChangeEvent);
+      this.emit('pane-focus-changed', {
+        type: 'pane-focus-changed',
+        timestamp,
+        source: 'hooks',
+      } as PaneFocusEvent);
     }, 100); // 100ms debounce
   }
 
@@ -143,6 +156,15 @@ export class PaneEventService extends EventEmitter {
               timestamp: message.timestamp,
               source: 'polling',
             } as PaneChangeEvent);
+            break;
+
+          case 'pane-focus-changed':
+            this.emit('pane-focus-changed', {
+              type: 'pane-focus-changed',
+              activePaneId: message.activePaneId,
+              timestamp: message.timestamp,
+              source: 'polling',
+            } as PaneFocusEvent);
             break;
 
           case 'error':
@@ -217,11 +239,17 @@ export class PaneEventService extends EventEmitter {
       this.pollingWorker.postMessage({ type: 'force-poll' });
     } else if (this.mode === 'hooks') {
       // Emit event immediately
+      const timestamp = Date.now();
       this.emit('panes-changed', {
         type: 'panes-changed',
-        timestamp: Date.now(),
+        timestamp,
         source: 'hooks',
       } as PaneChangeEvent);
+      this.emit('pane-focus-changed', {
+        type: 'pane-focus-changed',
+        timestamp,
+        source: 'hooks',
+      } as PaneFocusEvent);
     }
   }
 
@@ -275,6 +303,15 @@ export class PaneEventService extends EventEmitter {
   onPanesChanged(callback: (event: PaneChangeEvent) => void): () => void {
     this.on('panes-changed', callback);
     return () => this.off('panes-changed', callback);
+  }
+
+  /**
+   * Subscribe to pane focus events
+   * Returns an unsubscribe function
+   */
+  onPaneFocusChanged(callback: (event: PaneFocusEvent) => void): () => void {
+    this.on('pane-focus-changed', callback);
+    return () => this.off('pane-focus-changed', callback);
   }
 
   /**

--- a/src/services/PopupManager.ts
+++ b/src/services/PopupManager.ts
@@ -1023,7 +1023,7 @@ export class PopupManager {
     initialState: ReopenWorktreePopupState = {
       includeWorktrees: true,
       includeLocalBranches: true,
-      includeRemoteBranches: false,
+      includeRemoteBranches: true,
       remoteLoaded: false,
       filterQuery: "",
     },

--- a/src/services/TmuxService.ts
+++ b/src/services/TmuxService.ts
@@ -318,6 +318,24 @@ export class TmuxService {
   }
 
   /**
+   * Get the pane currently selected in the active dmux window.
+   *
+   * This uses pane_active from list-panes instead of display-message so it
+   * reflects tmux focus changes after this process was launched.
+   */
+  async getActivePaneId(scope: PaneListScope = 'window'): Promise<string | null> {
+    return this.executeWithRetry(
+      () => {
+        const lines = this.listPanesLines('#{pane_id} #{pane_active}', scope);
+        const activeLine = lines.find((line) => line.endsWith(' 1'));
+        return activeLine ? activeLine.split(' ')[0] : null;
+      },
+      RetryStrategy.IDEMPOTENT,
+      `getActivePaneId(${scope})`
+    );
+  }
+
+  /**
    * Get current window ID
    */
   async getCurrentWindowId(): Promise<string> {

--- a/src/utils/paneCreation.ts
+++ b/src/utils/paneCreation.ts
@@ -12,7 +12,7 @@ import {
 import { SIDEBAR_WIDTH, recalculateAndApplyLayout } from './layoutManager.js';
 import { generateSlug } from './slug.js';
 import { capturePaneContent } from './paneCapture.js';
-import { triggerHook, initializeHooksDirectory } from './hooks.js';
+import { triggerHook, triggerHookSync, initializeHooksDirectory } from './hooks.js';
 import { TMUX_LAYOUT_APPLY_DELAY, TMUX_SPLIT_DELAY } from '../constants/timing.js';
 import { atomicWriteJsonSync } from './atomicWrite.js';
 import { LogService } from '../services/LogService.js';
@@ -470,21 +470,80 @@ export async function createPane(
       initializeHooksDirectory(worktreePath);
     }
   } catch (error) {
-    // Worktree creation failed - send helpful error message to the pane
+    // Worktree creation failed - kill the pane and abort. Leaving the pane
+    // open at projectRoot is dangerous because the agent would run against
+    // the main checkout instead of an isolated worktree.
     const errorMsg = error instanceof Error ? error.message : String(error);
-    await tmuxService.sendShellCommand(
-      paneInfo,
-      `echo "❌ Failed to create worktree: ${errorMsg}"`
+    LogService.getInstance().error(
+      `Worktree creation failed for ${slug}: ${errorMsg}`,
+      'paneCreation',
+      undefined,
+      error instanceof Error ? error : undefined
     );
-    await tmuxService.sendTmuxKeys(paneInfo, 'Enter');
-    await tmuxService.sendShellCommand(
-      paneInfo,
-      `echo "Tip: Try running: git worktree prune && git branch -D ${branchName}"`
-    );
-    await tmuxService.sendTmuxKeys(paneInfo, 'Enter');
-    await new Promise((resolve) => setTimeout(resolve, TMUX_LAYOUT_APPLY_DELAY));
+    try {
+      await tmuxService.killPane(paneInfo);
+    } catch (killError) {
+      LogService.getInstance().warn(
+        `Failed to kill pane ${paneInfo} after worktree creation failure: ${killError}`,
+        'paneCreation'
+      );
+    }
+    if (controlPaneId) {
+      try {
+        await tmuxService.selectPane(controlPaneId);
+      } catch {
+        // best-effort focus restore
+      }
+    }
+    throw new Error(`Failed to create worktree for "${slug}": ${errorMsg}`);
+  }
 
-    // Don't throw - let the pane stay open so user can debug
+  // Build the pane object now so the worktree_created hook can receive full
+  // pane context. The hook must succeed before we launch the agent — a
+  // failing hook means the worktree is in an unknown state and running a
+  // prompt against it would be dangerous.
+  const newPane: DmuxPane = {
+    id: `dmux-${Date.now()}`,
+    slug,
+    displayName: existingWorktreeMetadata?.displayName,
+    branchName: branchName !== slug ? branchName : undefined,
+    prompt: prompt || 'No initial prompt',
+    paneId: paneInfo,
+    projectRoot,
+    projectName: paneProjectName,
+    worktreePath,
+    agent,
+    permissionMode: settings.permissionMode,
+    autopilot: settings.enableAutopilotByDefault ?? false,
+    mergeTargetChain,
+  };
+
+  // Run worktree_created hook synchronously BEFORE launching the agent.
+  // If the hook fails, tear down the pane and abort so the agent never
+  // runs against a half-configured worktree.
+  const hookResult = await triggerHookSync('worktree_created', projectRoot, newPane);
+  if (!hookResult.success) {
+    const hookError = hookResult.error || 'unknown error';
+    LogService.getInstance().error(
+      `worktree_created hook failed for ${slug}: ${hookError}`,
+      'paneCreation'
+    );
+    try {
+      await tmuxService.killPane(paneInfo);
+    } catch (killError) {
+      LogService.getInstance().warn(
+        `Failed to kill pane ${paneInfo} after worktree_created hook failure: ${killError}`,
+        'paneCreation'
+      );
+    }
+    if (controlPaneId) {
+      try {
+        await tmuxService.selectPane(controlPaneId);
+      } catch {
+        // best-effort focus restore
+      }
+    }
+    throw new Error(`worktree_created hook failed for "${slug}": ${hookError}`);
   }
 
   // Launch agent if specified
@@ -569,24 +628,6 @@ export async function createPane(
   // Keep focus on the new pane
   await tmuxService.selectPane(paneInfo);
 
-  // Create the pane object
-  const newPane: DmuxPane = {
-    id: `dmux-${Date.now()}`,
-    slug,
-    displayName: existingWorktreeMetadata?.displayName,
-    branchName: branchName !== slug ? branchName : undefined, // Only store if different from slug
-    prompt: prompt || 'No initial prompt',
-    paneId: paneInfo,
-    projectRoot,
-    projectName: paneProjectName,
-    worktreePath,
-    agent,
-    permissionMode: settings.permissionMode,
-    // Set autopilot based on settings (use ?? to properly handle false vs undefined)
-    autopilot: settings.enableAutopilotByDefault ?? false,
-    mergeTargetChain,
-  };
-
   // CRITICAL: Save the pane to config IMMEDIATELY before destroying welcome pane.
   // Only needed for the first content pane — ensures loadPanes sees a pane in config
   // before we kill the welcome pane (prevents spurious "0 panes" welcome recreation).
@@ -614,9 +655,6 @@ export async function createPane(
   } catch {
     // Ignore - welcome pane cleanup is not critical
   }
-
-  // Trigger worktree_created hook (after full pane setup)
-  await triggerHook('worktree_created', projectRoot, newPane);
 
   // Switch back to the original pane
   await tmuxService.selectPane(originalPaneId);

--- a/src/utils/projectActions.ts
+++ b/src/utils/projectActions.ts
@@ -22,6 +22,12 @@ export interface ProjectActionLayout {
   multiProjectMode: boolean;
 }
 
+export interface PostCloseSelection {
+  selectedIndex: number;
+  pane?: DmuxPane;
+  action?: ProjectActionItem;
+}
+
 function sameRoot(a: string, b: string): boolean {
   return path.resolve(a) === path.resolve(b);
 }
@@ -109,6 +115,89 @@ export function getProjectActionByIndex(
   index: number
 ): ProjectActionItem | undefined {
   return actionItems.find((item) => item.index === index);
+}
+
+export function resolveSelectionAfterPaneClose(
+  panes: DmuxPane[],
+  closingPaneId: string,
+  sidebarProjects: SidebarProject[],
+  fallbackProjectRoot: string,
+  fallbackProjectName: string
+): PostCloseSelection | null {
+  const currentLayout = buildProjectActionLayout(
+    panes,
+    sidebarProjects,
+    fallbackProjectRoot,
+    fallbackProjectName
+  );
+
+  let closingGroup: PaneProjectGroup | undefined;
+  let closingGroupPaneIndex = -1;
+  let closingPane: DmuxPane | undefined;
+
+  for (const group of currentLayout.groups) {
+    const groupIndex = group.panes.findIndex(
+      (entry) =>
+        entry.pane.id === closingPaneId ||
+        entry.pane.paneId === closingPaneId
+    );
+    if (groupIndex !== -1) {
+      closingGroup = group;
+      closingGroupPaneIndex = groupIndex;
+      closingPane = group.panes[groupIndex].pane;
+      break;
+    }
+  }
+
+  if (!closingGroup || !closingPane) {
+    return null;
+  }
+
+  const closingProjectRoot = closingGroup.projectRoot;
+  const updatedPanes = panes.filter((pane) => pane.id !== closingPane.id);
+  const nextLayout = buildProjectActionLayout(
+    updatedPanes,
+    sidebarProjects,
+    fallbackProjectRoot,
+    fallbackProjectName
+  );
+  const nextGroup = nextLayout.groups.find((group) =>
+    sameRoot(group.projectRoot, closingProjectRoot)
+  );
+  const nextPane = nextGroup?.panes[closingGroupPaneIndex];
+
+  if (nextPane) {
+    return {
+      selectedIndex: nextPane.index,
+      pane: nextPane.pane,
+    };
+  }
+
+  const newAgentAction = nextLayout.actionItems.find(
+    (action) =>
+      action.kind === 'new-agent' &&
+      sameRoot(action.projectRoot, closingProjectRoot)
+  );
+
+  if (newAgentAction) {
+    return {
+      selectedIndex: newAgentAction.index,
+      action: newAgentAction,
+    };
+  }
+
+  const fallbackAction = nextLayout.actionItems.find(
+    (action) => action.kind === 'new-agent'
+  );
+
+  if (fallbackAction) {
+    return {
+      selectedIndex: fallbackAction.index,
+      action: fallbackAction,
+    };
+  }
+
+  return null;
 }
 
 /**

--- a/src/utils/resumeBranches.ts
+++ b/src/utils/resumeBranches.ts
@@ -251,6 +251,14 @@ function listRemoteBranches(repoPath: string, remoteName: string): Set<string> {
   );
 }
 
+function fetchRemoteBranches(repoPath: string, remoteName: string): void {
+  runGit(
+    repoPath,
+    ['fetch', '--prune', remoteName],
+    { silent: true }
+  );
+}
+
 function compareCandidates(
   left: ResumableBranchCandidate,
   right: ResumableBranchCandidate
@@ -294,9 +302,12 @@ export function getResumableBranches(
 
   for (const repoPath of discoverWorkspaceRepos(projectRoot)) {
     const localBranches = listLocalBranches(repoPath);
-    const remoteBranches = includeRemoteBranches
-      ? listRemoteBranches(repoPath, getPreferredRemoteName(repoPath))
-      : new Set<string>();
+    let remoteBranches = new Set<string>();
+    if (includeRemoteBranches) {
+      const remoteName = getPreferredRemoteName(repoPath);
+      fetchRemoteBranches(repoPath, remoteName);
+      remoteBranches = listRemoteBranches(repoPath, remoteName);
+    }
     const branchNames = new Set<string>([
       ...Array.from(localBranches),
       ...Array.from(remoteBranches),

--- a/src/utils/toastLayout.ts
+++ b/src/utils/toastLayout.ts
@@ -1,0 +1,40 @@
+import stringWidth from 'string-width';
+import { SIDEBAR_WIDTH } from './layoutManager.js';
+
+interface ToastLike {
+  message: string;
+}
+
+export interface ToastSectionLayout {
+  footerExtraLines: number;
+  toastHeight: number;
+}
+
+export function getToastSectionLayout(
+  currentToast: ToastLike | null | undefined,
+  toastQueueLength: number,
+  availableWidth: number = SIDEBAR_WIDTH - 2,
+): ToastSectionLayout {
+  if (currentToast) {
+    const iconAndSpaceWidth = 2;
+    const toastDisplayWidth = iconAndSpaceWidth + stringWidth(currentToast.message);
+    const wrappedLines = Math.max(1, Math.ceil(toastDisplayWidth / availableWidth));
+
+    return {
+      footerExtraLines: wrappedLines + 2,
+      toastHeight: wrappedLines + 1,
+    };
+  }
+
+  if (toastQueueLength > 0) {
+    return {
+      footerExtraLines: 2,
+      toastHeight: 1,
+    };
+  }
+
+  return {
+    footerExtraLines: 0,
+    toastHeight: 0,
+  };
+}

--- a/src/workers/panePollingWorker.ts
+++ b/src/workers/panePollingWorker.ts
@@ -21,6 +21,7 @@ interface WorkerConfig {
 
 interface PaneSnapshot {
   paneIds: string[];
+  activePaneId: string | null;
   timestamp: number;
 }
 
@@ -49,6 +50,20 @@ function getPaneIds(): string[] {
   }
 }
 
+function getActivePaneId(): string | null {
+  try {
+    const output = execSync('tmux list-panes -F "#{pane_id} #{pane_active}"', {
+      encoding: 'utf8',
+      stdio: 'pipe',
+      timeout: 2000,
+    });
+    const activeLine = output.trim().split('\n').find((line) => line.endsWith(' 1'));
+    return activeLine ? activeLine.split(' ')[0] : null;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Compare two snapshots and detect changes
  */
@@ -56,9 +71,10 @@ function detectChanges(oldSnapshot: PaneSnapshot | null, newSnapshot: PaneSnapsh
   added: string[];
   removed: string[];
   changed: boolean;
+  focusChanged: boolean;
 } {
   if (!oldSnapshot) {
-    return { added: [], removed: [], changed: false };
+    return { added: [], removed: [], changed: false, focusChanged: false };
   }
 
   const oldSet = new Set(oldSnapshot.paneIds);
@@ -67,8 +83,9 @@ function detectChanges(oldSnapshot: PaneSnapshot | null, newSnapshot: PaneSnapsh
   const added = newSnapshot.paneIds.filter(id => !oldSet.has(id));
   const removed = oldSnapshot.paneIds.filter(id => !newSet.has(id));
   const changed = added.length > 0 || removed.length > 0;
+  const focusChanged = oldSnapshot.activePaneId !== newSnapshot.activePaneId;
 
-  return { added, removed, changed };
+  return { added, removed, changed, focusChanged };
 }
 
 /**
@@ -78,8 +95,10 @@ async function poll(): Promise<void> {
   while (isRunning) {
     try {
       const paneIds = getPaneIds();
+      const activePaneId = getActivePaneId();
       const newSnapshot: PaneSnapshot = {
         paneIds,
+        activePaneId,
         timestamp: Date.now(),
       };
 
@@ -92,6 +111,14 @@ async function poll(): Promise<void> {
           added: changes.added,
           removed: changes.removed,
           paneIds: paneIds,
+          timestamp: newSnapshot.timestamp,
+        });
+      }
+
+      if (changes.focusChanged) {
+        parentPort?.postMessage({
+          type: 'pane-focus-changed',
+          activePaneId,
           timestamp: newSnapshot.timestamp,
         });
       }
@@ -131,11 +158,18 @@ parentPort?.on('message', (message: { type: string; pollInterval?: number }) => 
     case 'force-poll':
       // Force an immediate poll
       const paneIds = getPaneIds();
+      const activePaneId = getActivePaneId();
       parentPort?.postMessage({
         type: 'panes-changed',
         added: [],
         removed: [],
         paneIds,
+        timestamp: Date.now(),
+        forced: true,
+      });
+      parentPort?.postMessage({
+        type: 'pane-focus-changed',
+        activePaneId,
         timestamp: Date.now(),
         forced: true,
       });


### PR DESCRIPTION
## Summary

- Fixes #63. `before_worktree_remove` was firing via `triggerHook()` (detached, `child.unref()`), so dmux proceeded straight to `git worktree remove --force` while the hook was still running. Cleanup scripts that read the worktree (bundled teardown scripts like `bin/rails db:drop`, reading config files) were SIGKILL'd as the directory vanished underneath them.
- Switched this one hook to `triggerHookSync()` so the worktree still exists until the hook returns. Other hooks stay fire-and-forget — `before_worktree_remove` is the one whose whole purpose is cleanup against state that's about to be destroyed.
- Updated the matching test mock + assertion.

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm run test` (513 passed)
- [ ] Manual: add a `before_worktree_remove` hook that writes a file into the worktree and sleeps, close the pane, confirm the hook finishes before the worktree directory is removed