### PR TITLE
fix(windows): use os.homedir() fallback so dmux starts on Windows

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import chalk from 'chalk';
 import fs from 'fs/promises';
 import * as fsSync from 'fs';
 import path from 'path';
+import os from 'os';
 import { render } from 'ink';
 import React from 'react';
 import { createHash } from 'crypto';
@@ -1145,7 +1146,7 @@ class Dmux {
     const dmuxDir = path.join(this.projectRoot, '.dmux');
     const newConfigFile = path.join(dmuxDir, 'dmux.config.json');
     const oldParentConfigFile = path.join(path.dirname(this.projectRoot), 'dmux.config.json');
-    const homeDmuxDir = path.join(process.env.HOME!, '.dmux');
+    const homeDmuxDir = path.join(process.env.HOME || os.homedir(), '.dmux');
 
     if (this.panesFile === newConfigFile && !await this.fileExists(newConfigFile)) {
       // Look for old config files to migrate


### PR DESCRIPTION
## Summary

Fixes #85.

On Windows, `process.env.HOME` is `undefined` (Windows uses `USERPROFILE`). At `src/index.ts:1148`:

```ts
const homeDmuxDir = path.join(process.env.HOME!, '.dmux');
```

The `!` non-null assertion lies to the type checker. At runtime, `path.join(undefined, ...)` throws `TypeError: The "path" argument must be of type string. Received undefined`. The exception is swallowed by `.catch(() => process.exit(1))` at the bottom of `init()`, so Windows users see dmux silently exit with code 1 and never get past `migrateOldConfig()`.

This PR replaces `process.env.HOME!` with `process.env.HOME || os.homedir()`, matching the safe pattern already used elsewhere in the codebase (`src/utils/onboarding.ts`, `src/utils/openRouterApiKeySetup.ts`, `src/utils/tmuxConfigOnboarding.ts`).

## Changes

- `src/index.ts`:
  - Add `import os from 'os';`
  - Replace `process.env.HOME!` with `process.env.HOME || os.homedir()` in `migrateOldConfig()`

## Note on `src/server/embedded-assets.ts`

The same buggy line exists at `src/server/embedded-assets.ts:1374` inside a template literal. That file has a `DO NOT EDIT MANUALLY - Generated by scripts/embed-assets.js` header, so I left it alone in this PR. Whatever generator produces it should pick up this change on the next regeneration. Happy to include a follow-up if you'd like it patched manually in the meantime.

## Test plan

- [x] On Windows 11 / PowerShell 7, with the same patch applied locally to the installed dmux, dmux now successfully writes `dmux.config.json` and proceeds past `migrateOldConfig()` (exit 0 in non-TTY harness, ink UI launches in real terminals).
- [ ] On macOS/Linux: behavior unchanged because `process.env.HOME` is set, so the `||` short-circuits before `os.homedir()` is even called. (No CI run yet from my fork.)
