### PR TITLE
Sanitize whitespace in tmux session names

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -658,7 +658,7 @@ class Dmux {
     const projectName = path.basename(projectRoot);
     const projectHash = createHash('md5').update(projectRoot).digest('hex').substring(0, 8);
     const projectIdentifier = `${projectName}-${projectHash}`;
-    const sanitizedProjectIdentifier = projectIdentifier.replace(/\./g, '-');
+    const sanitizedProjectIdentifier = projectIdentifier.replace(/[^a-zA-Z0-9_-]+/g, '-');
     return `dmux-${sanitizedProjectIdentifier}`;
   }
 


### PR DESCRIPTION
Project paths containing spaces produced session names like `dmux-my project-abcd1234`. Those names get interpolated unquoted into chained tmux commands in `applySessionPaneBorderOptions` (e.g. `tmux set-option -t ${sessionName} pane-border-status top \; set-option ...`), which tmux then parses with extra tokens and aborts:

```
command set-option: too many arguments (need at most 2)
```

Fix: replace any non-`[A-Za-z0-9_-]` run with `-` when building the session identifier (a superset of the existing `.` sanitization).

Repro: `mkdir "/tmp/foo bar" && cd "/tmp/foo bar" && git init && dmux`

(I ran into this problem while using WSL within Windows, on MacOS this did not occur with space names, FYI).