### PR TITLE
fix(codex): use --enable hooks instead of deprecated codex_hooks

### DIFF
--- a/__tests__/codexHooks.test.ts
+++ b/__tests__/codexHooks.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildCodexHookedCommand,
+  CODEX_ENABLE_HOOKS_FLAG,
+  enableCodexHooksFlag,
+} from '../src/utils/codexHooks.js';
+
+describe('codexHooks', () => {
+  it('uses the supported hooks feature flag when enabling Codex hooks', () => {
+    expect(enableCodexHooksFlag('codex resume --last')).toBe(
+      `codex ${CODEX_ENABLE_HOOKS_FLAG} resume --last`
+    );
+  });
+
+  it('prefixes exported dmux variables before enabling hooks', () => {
+    expect(buildCodexHookedCommand('codex resume --last', {
+      dmuxPaneId: 'dmux-1',
+      tmuxPaneId: '%9',
+      eventFile: '/tmp/dmux-event.json',
+    })).toBe(
+      "export DMUX_PANE_ID='dmux-1'; export DMUX_TMUX_PANE_ID='%9'; export DMUX_CODEX_HOOK_EVENT_FILE='/tmp/dmux-event.json'; codex --enable hooks resume --last"
+    );
+  });
+});

--- a/__tests__/paneRestore.test.ts
+++ b/__tests__/paneRestore.test.ts
@@ -51,7 +51,7 @@ describe('pane restoration', () => {
     expect(tmuxServiceMock.sendShellCommand).toHaveBeenCalledWith(
       '%9',
       expect.stringContaining(
-        "export DMUX_PANE_ID='dmux-1'; export DMUX_TMUX_PANE_ID='%9'; codex --enable codex_hooks resume --last --dangerously-bypass-approvals-and-sandbox"
+        "export DMUX_PANE_ID='dmux-1'; export DMUX_TMUX_PANE_ID='%9'; codex --enable hooks resume --last --dangerously-bypass-approvals-and-sandbox"
       )
     );
     expect(tmuxServiceMock.sendTmuxKeys).toHaveBeenCalledWith('%9', 'Enter');

--- a/__tests__/reopenWorktree.test.ts
+++ b/__tests__/reopenWorktree.test.ts
@@ -122,7 +122,7 @@ describe('reopenWorktree', () => {
     expect(tmuxServiceMock.sendShellCommand).toHaveBeenCalledWith(
       '%1',
       expect.stringMatching(
-        /^export DMUX_PANE_ID='dmux-\d+'; export DMUX_TMUX_PANE_ID='%1'; codex --enable codex_hooks resume --last --dangerously-bypass-approvals-and-sandbox$/
+        /^export DMUX_PANE_ID='dmux-\d+'; export DMUX_TMUX_PANE_ID='%1'; codex --enable hooks resume --last --dangerously-bypass-approvals-and-sandbox$/
       )
     );
     expect(tmuxServiceMock.setSessionOptionSync).toHaveBeenCalledWith(

--- a/src/utils/agentLaunch.ts
+++ b/src/utils/agentLaunch.ts
@@ -6,6 +6,7 @@ import {
 } from './promptStore.js';
 import {
   buildCodexPaneEnvironmentPrefix,
+  CODEX_ENABLE_HOOKS_FLAG,
 } from './codexHooks.js';
 
 export const AGENT_IDS = [
@@ -599,12 +600,12 @@ export async function launchAgentInPane(opts: {
 
       if (promptFilePath) {
         const promptBootstrap = buildPromptReadAndDeleteSnippet(promptFilePath);
-        codexCmd = `${promptBootstrap}; ${codexEnvPrefix} codex --enable codex_hooks "$DMUX_PROMPT_CONTENT"${permissionSuffix}`;
+        codexCmd = `${promptBootstrap}; ${codexEnvPrefix} codex ${CODEX_ENABLE_HOOKS_FLAG} "$DMUX_PROMPT_CONTENT"${permissionSuffix}`;
       } else {
-        codexCmd = `${codexEnvPrefix} codex --enable codex_hooks ${shellQuote(prompt)}${permissionSuffix}`;
+        codexCmd = `${codexEnvPrefix} codex ${CODEX_ENABLE_HOOKS_FLAG} ${shellQuote(prompt)}${permissionSuffix}`;
       }
     } else {
-      codexCmd = `${codexEnvPrefix} codex --enable codex_hooks${permissionSuffix}`;
+      codexCmd = `${codexEnvPrefix} codex ${CODEX_ENABLE_HOOKS_FLAG}${permissionSuffix}`;
     }
     await tmuxService.sendShellCommand(paneId, codexCmd);
     await tmuxService.sendTmuxKeys(paneId, 'Enter');

--- a/src/utils/codexHooks.ts
+++ b/src/utils/codexHooks.ts
@@ -161,8 +161,10 @@ export function buildCodexPaneExportSnippet(opts: {
     .join('; ');
 }
 
+export const CODEX_ENABLE_HOOKS_FLAG = '--enable hooks';
+
 export function enableCodexHooksFlag(command: string): string {
-  return command.replace(/(^|;\s*)codex(?=\s|$)/, '$1codex --enable codex_hooks');
+  return command.replace(/(^|;\s*)codex(?=\s|$)/, `$1codex ${CODEX_ENABLE_HOOKS_FLAG}`);
 }
 
 export function buildCodexHookedCommand(


### PR DESCRIPTION
Summary
  Codex CLI 0.129.0 warns that `codex_hooks` is deprecated and asks users to use `hooks` instead.

  dmux still launched Codex with `--enable codex_hooks`, which caused a warning every time Codex was started through dmux.

Changes
  - replace `--enable codex_hooks` with `--enable hooks`
  - centralize the flag in `CODEX_ENABLE_HOOKS_FLAG`
  - update reopen/restore tests
  - add a focused codex hooks test

Validation
  - `pnpm exec vitest --run __tests__/agentLaunch.test.ts __tests__/codexHooks.test.ts __tests__/paneRestore.test.ts __tests__/reopenWorktree.test.ts`
  - `pnpm run typecheck`