### PR TITLE
feat: support linked nested repos in pane workspaces

### DIFF
--- a/__tests__/integration/paneLifecycle.test.ts
+++ b/__tests__/integration/paneLifecycle.test.ts
@@ -326,7 +326,7 @@ describe('Pane Lifecycle Integration Tests', () => {
       )).toBe(false);
     });
 
-    it('passes configured linked child repos into the pane bootstrap config', async () => {
+    it('passes configured linked nested repos into the pane bootstrap config', async () => {
       fsMock.readFileSync.mockImplementation((target) => {
         const value = String(target);
         if (value.endsWith('/.dmux/settings.json')) {
@@ -358,7 +358,7 @@ describe('Pane Lifecycle Integration Tests', () => {
       ]);
     });
 
-    it('passes explicit linked child repo selections into the pane bootstrap config', async () => {
+    it('passes explicit linked nested repo selections into the pane bootstrap config', async () => {
       const { createPane } = await import('../../src/utils/paneCreation.js');
 
       await createPane(

--- a/__tests__/integration/paneLifecycle.test.ts
+++ b/__tests__/integration/paneLifecycle.test.ts
@@ -307,6 +307,7 @@ describe('Pane Lifecycle Integration Tests', () => {
           agent: 'claude',
           projectName: 'test-project',
           existingPanes: [],
+          slugBase: 'add-user',
         },
         ['claude']
       );
@@ -323,6 +324,60 @@ describe('Pane Lifecycle Integration Tests', () => {
       expect(mockExecSync.mock.calls.some(([cmd]) =>
         typeof cmd === 'string' && cmd.includes('git worktree add')
       )).toBe(false);
+    });
+
+    it('passes configured linked child repos into the pane bootstrap config', async () => {
+      fsMock.readFileSync.mockImplementation((target) => {
+        const value = String(target);
+        if (value.endsWith('/.dmux/settings.json')) {
+          return JSON.stringify({ linkedRepoPaths: 'packages/docs\nservices/api' });
+        }
+        if (value.endsWith('/.dmux/dmux.config.json')) {
+          return JSON.stringify({ controlPaneId: '%0' });
+        }
+        return JSON.stringify({});
+      });
+
+      const { createPane } = await import('../../src/utils/paneCreation.js');
+
+      await createPane(
+        {
+          prompt: 'open linked workspace',
+          agent: 'claude',
+          projectName: 'test-project',
+          existingPanes: [],
+          slugBase: 'linked-workspace',
+        },
+        ['claude']
+      );
+
+      const bootstrapConfig = getLatestBootstrapConfig();
+      expect(bootstrapConfig.metadata.linkedRepoPaths).toEqual([
+        'packages/docs',
+        'services/api',
+      ]);
+    });
+
+    it('passes explicit linked child repo selections into the pane bootstrap config', async () => {
+      const { createPane } = await import('../../src/utils/paneCreation.js');
+
+      await createPane(
+        {
+          prompt: 'open selected linked repos',
+          agent: 'claude',
+          projectName: 'test-project',
+          existingPanes: [],
+          slugBase: 'linked-selection',
+          linkedRepoPaths: ['external/infinite-canvas-web', 'backend/docs-ui'],
+        },
+        ['claude']
+      );
+
+      const bootstrapConfig = getLatestBootstrapConfig();
+      expect(bootstrapConfig.metadata.linkedRepoPaths).toEqual([
+        'external/infinite-canvas-web',
+        'backend/docs-ui',
+      ]);
     });
 
     it('passes remote tracking baseBranch values to bootstrap without forcing refs/heads', async () => {

--- a/__tests__/linkedRepoConfig.test.ts
+++ b/__tests__/linkedRepoConfig.test.ts
@@ -1,0 +1,69 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  discoverLinkedRepoPaths,
+  parseLinkedRepoPathsInput,
+  resolveLinkedRepoReferences,
+  validateLinkedRepoPathsSetting,
+} from '../src/utils/linkedRepoConfig.js';
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const tempDir = tempDirs.pop();
+    if (tempDir) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  }
+});
+
+describe('linkedRepoConfig', () => {
+  it('parses newline and comma separated repo paths into a deduped list', () => {
+    expect(parseLinkedRepoPathsInput('packages/docs, services/api\npackages/docs')).toEqual([
+      'packages/docs',
+      'services/api',
+    ]);
+  });
+
+  it('rejects linked repo paths that escape the project root', () => {
+    expect(() => validateLinkedRepoPathsSetting('../outside')).toThrow(
+      'cannot escape the project root'
+    );
+  });
+
+  it('resolves configured child repositories relative to the project root', () => {
+    const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'dmux-linked-repos-'));
+    tempDirs.push(projectRoot);
+
+    const childRepo = path.join(projectRoot, 'packages', 'docs');
+    fs.mkdirSync(path.join(childRepo, '.git'), { recursive: true });
+
+    expect(resolveLinkedRepoReferences(projectRoot, 'packages/docs')).toEqual([
+      {
+        relativePath: 'packages/docs',
+        repoPath: childRepo,
+      },
+    ]);
+  });
+
+  it('discovers nested child repositories while skipping generated directories', () => {
+    const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'dmux-linked-repo-discovery-'));
+    tempDirs.push(projectRoot);
+
+    const childRepo = path.join(projectRoot, 'external', 'infinite-canvas-web');
+    const nestedRepo = path.join(projectRoot, 'tools', 'workspace-helper');
+    const ignoredRepo = path.join(projectRoot, 'node_modules', 'ignored-package');
+
+    fs.mkdirSync(path.join(childRepo, '.git'), { recursive: true });
+    fs.mkdirSync(path.join(nestedRepo, '.git'), { recursive: true });
+    fs.mkdirSync(path.join(ignoredRepo, '.git'), { recursive: true });
+
+    expect(discoverLinkedRepoPaths(projectRoot)).toEqual([
+      'external/infinite-canvas-web',
+      'tools/workspace-helper',
+    ]);
+  });
+});

--- a/__tests__/linkedWorktrees.test.ts
+++ b/__tests__/linkedWorktrees.test.ts
@@ -1,0 +1,220 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const execMock = vi.hoisted(() => vi.fn());
+const execSyncMock = vi.hoisted(() => vi.fn());
+
+vi.mock('child_process', () => ({
+  exec: execMock,
+  execSync: execSyncMock,
+}));
+
+vi.mock('../src/utils/settingsManager.js', () => ({
+  SettingsManager: vi.fn(() => ({
+    getSettings: vi.fn(() => ({
+      linkedRepoPaths: undefined,
+    })),
+  })),
+}));
+
+type MockCommandOptions = {
+  cwd?: string;
+  encoding?: string;
+  stdio?: string;
+  maxBuffer?: number;
+};
+
+function installGitCommandMock(
+  handler: (command: string, options?: MockCommandOptions) => string | Buffer
+): void {
+  execSyncMock.mockImplementation((command: string, options?: MockCommandOptions) => (
+    handler(command, options)
+  ));
+
+  execMock.mockImplementation((
+    command: string,
+    optionsOrCallback?: MockCommandOptions | ((error: Error | null, stdout?: string, stderr?: string) => void),
+    maybeCallback?: (error: Error | null, stdout?: string, stderr?: string) => void
+  ) => {
+    const callback = typeof optionsOrCallback === 'function' ? optionsOrCallback : maybeCallback;
+    const options = typeof optionsOrCallback === 'function' ? undefined : optionsOrCallback;
+
+    if (!callback) {
+      throw new Error('exec callback is required in test mock');
+    }
+
+    try {
+      const result = handler(command, options);
+      callback(null, typeof result === 'string' ? result : result.toString('utf-8'), '');
+    } catch (error) {
+      callback(error as Error, '', '');
+    }
+
+    return {} as any;
+  });
+}
+
+describe('linkedWorktrees', () => {
+  let projectRoot: string;
+  let childRepo: string;
+  let rootWorktreePath: string;
+  let childWorktreePath: string;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'dmux-linked-worktrees-'));
+    childRepo = path.join(projectRoot, 'backend');
+    rootWorktreePath = path.join(projectRoot, '.dmux', 'worktrees', 'feature-test');
+    childWorktreePath = path.join(rootWorktreePath, 'backend');
+
+    fs.mkdirSync(path.join(projectRoot, '.git'), { recursive: true });
+    fs.mkdirSync(path.join(childRepo, '.git'), { recursive: true });
+    fs.mkdirSync(rootWorktreePath, { recursive: true });
+    fs.writeFileSync(path.join(rootWorktreePath, '.git'), 'gitdir: /tmp/root-worktree\n', 'utf-8');
+  });
+
+  afterEach(() => {
+    fs.rmSync(projectRoot, { recursive: true, force: true });
+  });
+
+  it('replaces an empty gitlink placeholder directory before attaching a child worktree', async () => {
+    fs.mkdirSync(childWorktreePath, { recursive: true });
+
+    const createdPaths: string[] = [];
+    installGitCommandMock((command: string, options?: { cwd?: string; encoding?: string }) => {
+      const cwd = options?.cwd;
+      const encoding = options?.encoding;
+      const output = (value: string) => encoding ? value : Buffer.from(value);
+
+      if (command.includes("'rev-parse' '--abbrev-ref' '--symbolic-full-name' '@{upstream}'")) {
+        return output('origin/main');
+      }
+      if (cwd === rootWorktreePath && command.includes("'branch' '--show-current'")) {
+        return output('feature/test');
+      }
+      if (command.includes("'branch' '--show-current'")) {
+        return output('main');
+      }
+      if (command.includes("'for-each-ref' '--format=%(refname:short)' 'refs/heads'")) {
+        return output('main\nfeature/test');
+      }
+      if (command.includes("'for-each-ref' '--format=%(refname:short)' 'refs/remotes/origin'")) {
+        return output('origin/feature/test');
+      }
+      if (command.includes("'fetch' '--prune' 'origin'")) {
+        return output('');
+      }
+      if (command.includes("'worktree' 'prune'")) {
+        return output('');
+      }
+      if (command.includes("'worktree' 'list' '--porcelain'")) {
+        return output('');
+      }
+      if (command.includes("'rev-parse' '--abbrev-ref' '--symbolic-full-name' 'feature/test@{upstream}'")) {
+        return output('origin/feature/test');
+      }
+      if (command.includes("'rev-list' '--left-right' '--count' 'feature/test...origin/feature/test'")) {
+        return output('0\t0');
+      }
+      if (command.includes("'worktree' 'add'")) {
+        const match = command.match(/'worktree' 'add' '([^']+)' 'feature\/test'/);
+        if (match) {
+          createdPaths.push(match[1]!);
+          fs.mkdirSync(match[1]!, { recursive: true });
+          fs.writeFileSync(path.join(match[1]!, '.git'), 'gitdir: /tmp/child-worktree\n', 'utf-8');
+        }
+        return output('');
+      }
+
+      throw new Error(`Unhandled git command: ${command} (cwd=${cwd})`);
+    });
+
+    const { ensureWorkspaceWorktrees } = await import('../src/utils/linkedWorktrees.js');
+
+    const targets = await ensureWorkspaceWorktrees({
+      projectRoot,
+      rootWorktreePath,
+      branchName: 'feature/test',
+      linkedRepoPaths: ['backend'],
+      fallbackStartPointMode: 'current-head',
+    });
+
+    expect(targets).toEqual([
+      {
+        isRoot: true,
+        repoPath: projectRoot,
+        relativePath: '',
+        worktreePath: rootWorktreePath,
+        createdWorktree: false,
+      },
+      {
+        isRoot: false,
+        repoPath: childRepo,
+        relativePath: 'backend',
+        worktreePath: childWorktreePath,
+        createdWorktree: true,
+      },
+    ]);
+    expect(createdPaths).toEqual([childWorktreePath]);
+    expect(fs.existsSync(path.join(childWorktreePath, '.git'))).toBe(true);
+  });
+
+  it('keeps rejecting non-empty directories that are not child worktrees', async () => {
+    fs.mkdirSync(childWorktreePath, { recursive: true });
+    fs.writeFileSync(path.join(childWorktreePath, 'README.md'), 'placeholder\n', 'utf-8');
+
+    installGitCommandMock((command: string, options?: { cwd?: string; encoding?: string }) => {
+      const cwd = options?.cwd;
+      const encoding = options?.encoding;
+      const output = (value: string) => encoding ? value : Buffer.from(value);
+
+      if (command.includes("'rev-parse' '--abbrev-ref' '--symbolic-full-name' '@{upstream}'")) {
+        return output('origin/main');
+      }
+      if (cwd === rootWorktreePath && command.includes("'branch' '--show-current'")) {
+        return output('feature/test');
+      }
+      if (command.includes("'branch' '--show-current'")) {
+        return output('main');
+      }
+      if (command.includes("'for-each-ref' '--format=%(refname:short)' 'refs/heads'")) {
+        return output('main\nfeature/test');
+      }
+      if (command.includes("'for-each-ref' '--format=%(refname:short)' 'refs/remotes/origin'")) {
+        return output('origin/feature/test');
+      }
+      if (command.includes("'fetch' '--prune' 'origin'")) {
+        return output('');
+      }
+      if (command.includes("'worktree' 'prune'")) {
+        return output('');
+      }
+      if (command.includes("'worktree' 'list' '--porcelain'")) {
+        return output('');
+      }
+      if (command.includes("'rev-parse' '--abbrev-ref' '--symbolic-full-name' 'feature/test@{upstream}'")) {
+        return output('origin/feature/test');
+      }
+      if (command.includes("'rev-list' '--left-right' '--count' 'feature/test...origin/feature/test'")) {
+        return output('0\t0');
+      }
+
+      throw new Error(`Unhandled git command: ${command}`);
+    });
+
+    const { ensureWorkspaceWorktrees } = await import('../src/utils/linkedWorktrees.js');
+
+    await expect(
+      ensureWorkspaceWorktrees({
+        projectRoot,
+        rootWorktreePath,
+        branchName: 'feature/test',
+        linkedRepoPaths: ['backend'],
+        fallbackStartPointMode: 'current-head',
+      })
+    ).rejects.toThrow(`Path already exists and is not a git worktree: ${childWorktreePath}`);
+  });
+});

--- a/__tests__/mergeValidation.test.ts
+++ b/__tests__/mergeValidation.test.ts
@@ -6,6 +6,10 @@ vi.mock('child_process', () => ({
   execSync: vi.fn(),
 }));
 
+vi.mock('../src/utils/worktreeMetadata.js', () => ({
+  readWorktreeMetadata: vi.fn(() => null),
+}));
+
 describe('mergeValidation', () => {
   beforeEach(() => {
     vi.mocked(execSync).mockReset();
@@ -59,6 +63,45 @@ describe('mergeValidation', () => {
       hasChanges: true,
       files: ['src/index.ts', 'package.json'],
       summary: 'M src/index.ts\nM package.json',
+    });
+  });
+
+  it('ignores linked nested repo paths when checking root repo status', async () => {
+    const { readWorktreeMetadata } = await import('../src/utils/worktreeMetadata.js');
+    vi.mocked(readWorktreeMetadata).mockReturnValue({
+      linkedRepoPaths: ['backend', 'frontend'],
+    });
+
+    vi.mocked(execSync).mockReturnValue(
+      ' M backend\n M frontend\nM src/index.ts\n'
+    );
+
+    const status = getGitStatus('/repo');
+
+    expect(status).toEqual({
+      hasChanges: true,
+      files: ['src/index.ts'],
+      summary: 'M src/index.ts',
+    });
+  });
+
+  it('ignores untracked agent hook state scaffolding', () => {
+    vi.mocked(execSync).mockReturnValue(
+      [
+        '?? .codex/',
+        '?? .codex/hooks.json',
+        '?? .codex/hooks/dmux-stop-hook.cjs',
+        '?? .claude/',
+        '?? .claude/settings.local.json',
+      ].join('\n')
+    );
+
+    const status = getGitStatus('/repo');
+
+    expect(status).toEqual({
+      hasChanges: false,
+      files: [],
+      summary: '',
     });
   });
 });

--- a/__tests__/newPaneFieldNavigation.test.ts
+++ b/__tests__/newPaneFieldNavigation.test.ts
@@ -16,4 +16,11 @@ describe('new pane field navigation', () => {
     expect(getPreviousNewPaneField('branchName')).toBe('baseBranch');
     expect(getPreviousNewPaneField('baseBranch')).toBe('prompt');
   });
+
+  it('includes linked repo selection in the cycle when child repos are available', () => {
+    expect(getNextNewPaneField('branchName', { hasLinkedRepos: true })).toBe('linkedRepos');
+    expect(getNextNewPaneField('linkedRepos', { hasLinkedRepos: true })).toBe('prompt');
+    expect(getPreviousNewPaneField('prompt', { hasLinkedRepos: true })).toBe('linkedRepos');
+    expect(getPreviousNewPaneField('linkedRepos', { hasLinkedRepos: true })).toBe('branchName');
+  });
 });

--- a/__tests__/popupManager.newPanePopup.test.ts
+++ b/__tests__/popupManager.newPanePopup.test.ts
@@ -179,6 +179,25 @@ describe('PopupManager launchNewPanePopup', () => {
     });
   });
 
+  it('normalizes linked child repo selections from popup payloads', async () => {
+    const manager = createPopupManager({ promptForGitOptionsOnCreate: true }) as any;
+    manager.checkPopupSupport = vi.fn(() => true);
+    manager.launchPopup = vi.fn().mockResolvedValue({
+      success: true,
+      data: {
+        prompt: 'prompt',
+        linkedRepoPaths: [' external/web ', 'packages/docs', 'external/web'],
+      },
+    });
+
+    const result = await manager.launchNewPanePopup('/tmp/project');
+
+    expect(result).toEqual({
+      prompt: 'prompt',
+      linkedRepoPaths: ['external/web', 'packages/docs'],
+    });
+  });
+
   it('returns null for malformed popup payloads', async () => {
     const manager = createPopupManager({ promptForGitOptionsOnCreate: true }) as any;
     manager.checkPopupSupport = vi.fn(() => true);

--- a/__tests__/popupManager.newPanePopup.test.ts
+++ b/__tests__/popupManager.newPanePopup.test.ts
@@ -121,13 +121,19 @@ describe('PopupManager launchNewPanePopup', () => {
 
     await manager.launchNewPanePopup(tempRoot);
 
-    expect(manager.launchPopup).toHaveBeenCalledWith(
-      'newPanePopup.js',
-      [tempRoot, '0', '1'],
-      expect.any(Object),
-      undefined,
-      tempRoot
-    );
+    expect(manager.launchPopup).toHaveBeenCalledTimes(1);
+    const [scriptName, popupArgs, popupOptions, popupData, popupProjectRoot] =
+      manager.launchPopup.mock.calls[0];
+
+    expect(scriptName).toBe('newPanePopup.js');
+    expect(popupArgs).toEqual([
+      tempRoot,
+      expect.any(String),
+      '1',
+    ]);
+    expect(popupOptions).toEqual(expect.any(Object));
+    expect(popupData).toBeUndefined();
+    expect(popupProjectRoot).toBe(tempRoot);
   });
 
   it('disables git options when caller requests allowGitOptions=false', async () => {

--- a/__tests__/popupManager.newPanePopup.test.ts
+++ b/__tests__/popupManager.newPanePopup.test.ts
@@ -179,7 +179,7 @@ describe('PopupManager launchNewPanePopup', () => {
     });
   });
 
-  it('normalizes linked child repo selections from popup payloads', async () => {
+  it('normalizes linked nested repo selections from popup payloads', async () => {
     const manager = createPopupManager({ promptForGitOptionsOnCreate: true }) as any;
     manager.checkPopupSupport = vi.fn(() => true);
     manager.launchPopup = vi.fn().mockResolvedValue({

--- a/__tests__/reopenWorktree.test.ts
+++ b/__tests__/reopenWorktree.test.ts
@@ -22,6 +22,9 @@ const recalculateAndApplyLayoutMock = vi.hoisted(() => vi.fn(async () => {}));
 const getInstalledAgentsMock = vi.hoisted(() => vi.fn(async () => ['claude', 'codex']));
 const filterEnabledAgentsMock = vi.hoisted(() => vi.fn((agents: string[]) => agents));
 const destroyWelcomePaneCoordinatedMock = vi.hoisted(() => vi.fn());
+const ensureWorkspaceWorktreesMock = vi.hoisted(() => vi.fn(async () => []));
+const getConfiguredLinkedRepoPathsMock = vi.hoisted(() => vi.fn(() => []));
+const writeWorktreeMetadataMock = vi.hoisted(() => vi.fn());
 const readWorktreeMetadataMock = vi.hoisted(() => vi.fn(() => ({
   agent: 'codex',
   permissionMode: 'bypassPermissions',
@@ -74,6 +77,12 @@ vi.mock('../src/utils/agentDetection.js', () => ({
 
 vi.mock('../src/utils/worktreeMetadata.js', () => ({
   readWorktreeMetadata: readWorktreeMetadataMock,
+  writeWorktreeMetadata: writeWorktreeMetadataMock,
+}));
+
+vi.mock('../src/utils/linkedWorktrees.js', () => ({
+  ensureWorkspaceWorktrees: ensureWorkspaceWorktreesMock,
+  getConfiguredLinkedRepoPaths: getConfiguredLinkedRepoPathsMock,
 }));
 
 vi.mock('../src/utils/paneTitle.js', () => ({
@@ -105,6 +114,56 @@ describe('reopenWorktree', () => {
       permissionMode: 'bypassPermissions',
       branchName: 'feature/reopen-me',
     });
+    ensureWorkspaceWorktreesMock.mockResolvedValue([]);
+    getConfiguredLinkedRepoPathsMock.mockReturnValue([]);
+  });
+
+  it('ensures linked child worktrees before resuming an existing pane', async () => {
+    readWorktreeMetadataMock.mockReturnValue({
+      agent: 'codex',
+      permissionMode: 'bypassPermissions',
+      branchName: 'feature/reopen-me',
+      linkedRepoPaths: ['packages/docs'],
+    });
+    ensureWorkspaceWorktreesMock.mockResolvedValue([
+      {
+        isRoot: true,
+        repoPath: '/repo',
+        relativePath: '',
+        worktreePath: '/repo/.dmux/worktrees/reopen-me',
+        createdWorktree: false,
+      },
+      {
+        isRoot: false,
+        repoPath: '/repo/packages/docs',
+        relativePath: 'packages/docs',
+        worktreePath: '/repo/.dmux/worktrees/reopen-me/packages/docs',
+        createdWorktree: true,
+      },
+    ]);
+
+    const { reopenWorktree } = await import('../src/utils/reopenWorktree.js');
+
+    await reopenWorktree({
+      slug: 'reopen-me',
+      worktreePath: '/repo/.dmux/worktrees/reopen-me',
+      projectRoot: '/repo',
+      existingPanes: [],
+      sessionProjectRoot: '/repo',
+      sessionConfigPath: '/repo/.dmux/dmux.config.json',
+    });
+
+    expect(ensureWorkspaceWorktreesMock).toHaveBeenCalledWith({
+      projectRoot: '/repo',
+      rootWorktreePath: '/repo/.dmux/worktrees/reopen-me',
+      branchName: 'feature/reopen-me',
+      linkedRepoPaths: ['packages/docs'],
+      fallbackStartPointMode: 'current-head',
+    });
+    expect(writeWorktreeMetadataMock).toHaveBeenCalledWith(
+      '/repo/.dmux/worktrees/reopen-me/packages/docs',
+      { branchName: 'feature/reopen-me' }
+    );
   });
 
   it('uses stored agent metadata and permission mode for resume', async () => {

--- a/__tests__/reopenWorktree.test.ts
+++ b/__tests__/reopenWorktree.test.ts
@@ -118,7 +118,7 @@ describe('reopenWorktree', () => {
     getConfiguredLinkedRepoPathsMock.mockReturnValue([]);
   });
 
-  it('ensures linked child worktrees before resuming an existing pane', async () => {
+  it('ensures linked nested repo worktrees before resuming an existing pane', async () => {
     readWorktreeMetadataMock.mockReturnValue({
       agent: 'codex',
       permissionMode: 'bypassPermissions',

--- a/__tests__/resumeBranches.test.ts
+++ b/__tests__/resumeBranches.test.ts
@@ -30,6 +30,7 @@ vi.mock('../src/utils/settingsManager.js', () => ({
   SettingsManager: vi.fn(() => ({
     getSettings: vi.fn(() => ({
       permissionMode: 'plan',
+      linkedRepoPaths: 'child-repo',
     })),
   })),
 }));
@@ -421,6 +422,7 @@ describe('resumeBranches', () => {
       expect.objectContaining({
         agent: 'codex',
         permissionMode: 'plan',
+        linkedRepoPaths: ['child-repo'],
         branchName: 'feature/remote-shared',
       })
     );

--- a/__tests__/worktreeMetadata.test.ts
+++ b/__tests__/worktreeMetadata.test.ts
@@ -29,6 +29,7 @@ describe('worktree metadata persistence', () => {
       goalMode: true,
       displayName: 'Review Queue',
       branchName: 'feat/child-worktree',
+      linkedRepoPaths: ['packages/design-system', 'services/api'],
       mergeTargetChain: [
         {
           displayName: 'Feature Parent',
@@ -50,6 +51,7 @@ describe('worktree metadata persistence', () => {
       goalMode: true,
       displayName: 'Review Queue',
       branchName: 'feat/child-worktree',
+      linkedRepoPaths: ['packages/design-system', 'services/api'],
       mergeTargetChain: [
         {
           displayName: 'Feature Parent',
@@ -63,6 +65,19 @@ describe('worktree metadata persistence', () => {
           worktreePath: '/repo',
         },
       ],
+    });
+  });
+
+  it('preserves an explicit empty linked repo selection so reopen does not fall back to project defaults', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dmux-worktree-meta-empty-'));
+    tempDirs.push(tempDir);
+
+    writeWorktreeMetadata(tempDir, {
+      linkedRepoPaths: [],
+    });
+
+    expect(readWorktreeMetadata(tempDir)).toEqual({
+      linkedRepoPaths: [],
     });
   });
 });

--- a/src/components/popups/newPaneFieldNavigation.ts
+++ b/src/components/popups/newPaneFieldNavigation.ts
@@ -4,16 +4,36 @@
  * Specifically, the 'prompt' -> 'base branch' -> 'new branch name' cycle.
  */
 
-export type NewPaneField = 'prompt' | 'baseBranch' | 'branchName';
+export type NewPaneField = 'prompt' | 'baseBranch' | 'branchName' | 'linkedRepos';
 
-export function getNextNewPaneField(current: NewPaneField): NewPaneField {
-  if (current === 'prompt') return 'baseBranch';
-  if (current === 'baseBranch') return 'branchName';
-  return 'prompt';
+function getFieldOrder(hasLinkedRepos: boolean): NewPaneField[] {
+  return hasLinkedRepos
+    ? ['prompt', 'baseBranch', 'branchName', 'linkedRepos']
+    : ['prompt', 'baseBranch', 'branchName'];
 }
 
-export function getPreviousNewPaneField(current: NewPaneField): NewPaneField {
-  if (current === 'prompt') return 'branchName';
-  if (current === 'baseBranch') return 'prompt';
-  return 'baseBranch';
+export function getNextNewPaneField(
+  current: NewPaneField,
+  options: { hasLinkedRepos?: boolean } = {}
+): NewPaneField {
+  const order = getFieldOrder(options.hasLinkedRepos ?? false);
+  const currentIndex = order.indexOf(current);
+  if (currentIndex === -1) {
+    return order[0];
+  }
+
+  return order[(currentIndex + 1) % order.length];
+}
+
+export function getPreviousNewPaneField(
+  current: NewPaneField,
+  options: { hasLinkedRepos?: boolean } = {}
+): NewPaneField {
+  const order = getFieldOrder(options.hasLinkedRepos ?? false);
+  const currentIndex = order.indexOf(current);
+  if (currentIndex === -1) {
+    return order[0];
+  }
+
+  return order[(currentIndex - 1 + order.length) % order.length];
 }

--- a/src/components/popups/newPanePopup.tsx
+++ b/src/components/popups/newPanePopup.tsx
@@ -36,6 +36,12 @@ import {
   getPreviousNewPaneField,
   type NewPaneField,
 } from "./newPaneFieldNavigation.js"
+import { SettingsManager } from "../../utils/settingsManager.js"
+import {
+  discoverLinkedRepoPaths,
+  normalizeLinkedRepoPathsArray,
+  resolveLinkedRepoReferences,
+} from "../../utils/linkedRepoConfig.js"
 import fs from "fs"
 import path from "path"
 import { pathToFileURL } from "url"
@@ -65,10 +71,13 @@ export const NewPanePopupApp: React.FC<{ resultFile: string }> = ({ resultFile }
   const [mode, setMode] = useState<'prompt' | 'gitOptions'>('prompt')
   const [baseBranch, setBaseBranch] = useState("")
   const [branchName, setBranchName] = useState("")
-  const [activeGitField, setActiveGitField] = useState<'baseBranch' | 'branchName'>('baseBranch')
+  const [activeGitField, setActiveGitField] = useState<'baseBranch' | 'branchName' | 'linkedRepos'>('baseBranch')
   const [availableBranches, setAvailableBranches] = useState<string[]>([])
   const [filteredBranches, setFilteredBranches] = useState<string[]>([])
   const [selectedBranchIndex, setSelectedBranchIndex] = useState(0)
+  const [availableLinkedRepos, setAvailableLinkedRepos] = useState<string[]>([])
+  const [selectedLinkedRepos, setSelectedLinkedRepos] = useState<string[]>([])
+  const [selectedLinkedRepoIndex, setSelectedLinkedRepoIndex] = useState(0)
   const [gitOptionsError, setGitOptionsError] = useState<string | null>(null)
   const [pendingClearEsc, setPendingClearEsc] = useState(false)
   const { exit } = useApp()
@@ -81,6 +90,7 @@ export const NewPanePopupApp: React.FC<{ resultFile: string }> = ({ resultFile }
   const [atPosition, setAtPosition] = useState(-1) // Position of @ in text
   const [cursorPosition, setCursorPosition] = useState<number | undefined>(undefined)
   const [currentCursor, setCurrentCursor] = useState(0) // Track cursor position from CleanTextInput
+  const hasLinkedRepoOptions = availableLinkedRepos.length > 0
 
   const getCurrentField = (): NewPaneField =>
     mode === 'prompt' ? 'prompt' : activeGitField
@@ -95,6 +105,21 @@ export const NewPanePopupApp: React.FC<{ resultFile: string }> = ({ resultFile }
     setActiveGitField(field)
   }
 
+  const moveGitFieldFocus = (direction: 'next' | 'previous') => {
+    const resolver = direction === 'next'
+      ? getNextNewPaneField
+      : getPreviousNewPaneField
+    setCurrentField(resolver(getCurrentField(), { hasLinkedRepos: hasLinkedRepoOptions }))
+  }
+
+  const toggleLinkedRepo = (relativePath: string) => {
+    setSelectedLinkedRepos((current) => (
+      current.includes(relativePath)
+        ? current.filter((candidate) => candidate !== relativePath)
+        : [...current, relativePath]
+    ))
+  }
+
   const writeSuccessResult = () => {
     const trimmedBaseBranch = baseBranch.trim()
     if (!isValidBaseBranchOverride(trimmedBaseBranch, availableBranches)) {
@@ -102,7 +127,13 @@ export const NewPanePopupApp: React.FC<{ resultFile: string }> = ({ resultFile }
       return
     }
 
-    const payload: { prompt: string; baseBranch?: string; branchName?: string; goalMode: boolean } = {
+    const payload: {
+      prompt: string;
+      baseBranch?: string;
+      branchName?: string;
+      goalMode: boolean;
+      linkedRepoPaths?: string[];
+    } = {
       prompt,
       goalMode,
     }
@@ -111,6 +142,9 @@ export const NewPanePopupApp: React.FC<{ resultFile: string }> = ({ resultFile }
 
     if (trimmedBaseBranch) payload.baseBranch = trimmedBaseBranch
     if (trimmedBranchName) payload.branchName = trimmedBranchName
+    if (hasLinkedRepoOptions) {
+      payload.linkedRepoPaths = normalizeLinkedRepoPathsArray(selectedLinkedRepos)
+    }
 
     writeSuccessAndExit(resultFile, payload, exit)
   }
@@ -122,6 +156,29 @@ export const NewPanePopupApp: React.FC<{ resultFile: string }> = ({ resultFile }
 
     const branches = loadLocalBranchNames(FILE_SCAN_ROOT)
     setAvailableBranches(branches)
+
+    const configuredLinkedRepoPaths = normalizeLinkedRepoPathsArray(
+      (() => {
+        try {
+          return resolveLinkedRepoReferences(
+            FILE_SCAN_ROOT,
+            new SettingsManager(FILE_SCAN_ROOT).getSettings().linkedRepoPaths
+          ).map((reference) => reference.relativePath)
+        } catch {
+          return []
+        }
+      })()
+    )
+    const discoveredLinkedRepos = discoverLinkedRepoPaths(FILE_SCAN_ROOT)
+    const selectableLinkedRepos = Array.from(new Set([
+      ...configuredLinkedRepoPaths,
+      ...discoveredLinkedRepos,
+    ])).sort((left, right) => left.localeCompare(right))
+
+    setAvailableLinkedRepos(selectableLinkedRepos)
+    setSelectedLinkedRepos(
+      configuredLinkedRepoPaths.length > 0 ? configuredLinkedRepoPaths : selectableLinkedRepos
+    )
   }, [])
 
   useEffect(() => {
@@ -141,7 +198,11 @@ export const NewPanePopupApp: React.FC<{ resultFile: string }> = ({ resultFile }
     if (gitOptionsError) {
       setGitOptionsError(null)
     }
-  }, [baseBranch, branchName])
+  }, [baseBranch, branchName, selectedLinkedRepos])
+
+  useEffect(() => {
+    setSelectedLinkedRepoIndex((previous) => clampSelectedIndex(previous, availableLinkedRepos.length))
+  }, [availableLinkedRepos.length])
 
   const resetPendingClearEsc = () => {
     if (clearEscTimeoutRef.current) {
@@ -308,12 +369,24 @@ export const NewPanePopupApp: React.FC<{ resultFile: string }> = ({ resultFile }
             setBaseBranch('')
           } else if (branchName.length > 0) {
             setActiveGitField('branchName')
+          } else if (hasLinkedRepoOptions) {
+            setActiveGitField('linkedRepos')
+          } else {
+            setMode('prompt')
+          }
+        } else if (activeGitField === 'branchName') {
+          if (branchName.length > 0) {
+            setBranchName('')
+          } else if (baseBranch.length > 0) {
+            setActiveGitField('baseBranch')
+          } else if (hasLinkedRepoOptions) {
+            setActiveGitField('linkedRepos')
           } else {
             setMode('prompt')
           }
         } else {
           if (branchName.length > 0) {
-            setBranchName('')
+            setActiveGitField('branchName')
           } else if (baseBranch.length > 0) {
             setActiveGitField('baseBranch')
           } else {
@@ -330,8 +403,12 @@ export const NewPanePopupApp: React.FC<{ resultFile: string }> = ({ resultFile }
           setSelectedBranchIndex((prev) => Math.max(0, prev - 1))
           return
         }
+        if (activeGitField === 'linkedRepos' && availableLinkedRepos.length > 0) {
+          setSelectedLinkedRepoIndex((prev) => Math.max(0, prev - 1))
+          return
+        }
 
-        setActiveGitField('baseBranch')
+        moveGitFieldFocus('previous')
         return
       }
 
@@ -342,23 +419,45 @@ export const NewPanePopupApp: React.FC<{ resultFile: string }> = ({ resultFile }
           setSelectedBranchIndex((prev) => Math.min(filteredBranches.length - 1, prev + 1))
           return
         }
+        if (activeGitField === 'linkedRepos' && availableLinkedRepos.length > 0) {
+          setSelectedLinkedRepoIndex((prev) => Math.min(availableLinkedRepos.length - 1, prev + 1))
+          return
+        }
 
-        setActiveGitField('branchName')
+        moveGitFieldFocus('next')
         return
       }
 
       // Tab and Shift+Tab cycle across prompt/base/branch fields.
       if (isForwardTab || isBackTab) {
-        const nextField = isForwardTab
-          ? getNextNewPaneField(getCurrentField())
-          : getPreviousNewPaneField(getCurrentField())
-        setCurrentField(nextField)
+        moveGitFieldFocus(isForwardTab ? 'next' : 'previous')
         return
+      }
+
+      if (activeGitField === 'linkedRepos') {
+        if (input === ' ') {
+          const relativePath = availableLinkedRepos[selectedLinkedRepoIndex]
+          if (relativePath) {
+            toggleLinkedRepo(relativePath)
+          }
+          return
+        }
+
+        if (input.toLowerCase() === 'a') {
+          setSelectedLinkedRepos(availableLinkedRepos)
+          return
+        }
+
+        if (input.toLowerCase() === 'n') {
+          setSelectedLinkedRepos([])
+          return
+        }
       }
 
       // Enter is a two-step action:
       // - on base field: accept highlighted/exact branch, then move to branch field
-      // - on branch field: submit both overrides + prompt payload
+      // - on branch field: move to linked repos (when available) or submit
+      // - on linked repos: submit prompt + overrides + selected repos
       if (key.return) {
         if (activeGitField === 'baseBranch') {
           const resolution = resolveBaseBranchEnter({
@@ -375,6 +474,8 @@ export const NewPanePopupApp: React.FC<{ resultFile: string }> = ({ resultFile }
 
           setBaseBranch(resolution.nextValue)
           setActiveGitField('branchName')
+        } else if (activeGitField === 'branchName' && hasLinkedRepoOptions) {
+          setActiveGitField('linkedRepos')
         } else {
           writeSuccessResult()
         }
@@ -397,10 +498,7 @@ export const NewPanePopupApp: React.FC<{ resultFile: string }> = ({ resultFile }
     // With git options enabled, Tab/Shift+Tab also cycle into git fields
     // from the prompt editor when file autocomplete is not active.
     if (ENABLE_GIT_OPTIONS_ARG && !isFileListActive && (isForwardTab || isBackTab)) {
-      const nextField = isForwardTab
-        ? getNextNewPaneField(getCurrentField())
-        : getPreviousNewPaneField(getCurrentField())
-      setCurrentField(nextField)
+      moveGitFieldFocus(isForwardTab ? 'next' : 'previous')
       return
     }
 
@@ -694,6 +792,46 @@ export const NewPanePopupApp: React.FC<{ resultFile: string }> = ({ resultFile }
                 placeholder="e.g., feat/LIN-123-fix-auth"
               />
             </Box>
+
+            {hasLinkedRepoOptions && (
+              <>
+                <Box marginTop={1} marginBottom={0}>
+                  <Text color={activeGitField === 'linkedRepos' ? POPUP_CONFIG.titleColor : 'white'}>
+                    {activeGitField === 'linkedRepos' ? '▶ ' : '  '}Linked child repos ({selectedLinkedRepos.length}/{availableLinkedRepos.length})
+                  </Text>
+                </Box>
+                <Box
+                  width="100%"
+                  borderStyle={POPUP_CONFIG.inputBorderStyle}
+                  borderColor={activeGitField === 'linkedRepos' ? POPUP_CONFIG.inputBorderColor : 'gray'}
+                  paddingX={POPUP_CONFIG.inputPadding.x}
+                  paddingY={POPUP_CONFIG.inputPadding.y}
+                  flexDirection="column"
+                >
+                  <Box marginBottom={0}>
+                    <Text dimColor>
+                      Auto-detected child repos for this pane. Space toggles • A selects all • N clears all
+                    </Text>
+                  </Box>
+
+                  {availableLinkedRepos.map((relativePath, index) => {
+                    const isActive = activeGitField === 'linkedRepos' && index === selectedLinkedRepoIndex
+                    const isSelected = selectedLinkedRepos.includes(relativePath)
+                    return (
+                      <Box key={relativePath}>
+                        <Text
+                          color={isActive ? 'black' : undefined}
+                          backgroundColor={isActive ? 'cyan' : undefined}
+                          bold={isActive}
+                        >
+                          {isActive ? '▶ ' : '  '}{isSelected ? '[x]' : '[ ]'} {relativePath}
+                        </Text>
+                      </Box>
+                    )
+                  })}
+                </Box>
+              </>
+            )}
           </>
         )}
       </PopupContainer>

--- a/src/components/popups/newPanePopup.tsx
+++ b/src/components/popups/newPanePopup.tsx
@@ -797,7 +797,7 @@ export const NewPanePopupApp: React.FC<{ resultFile: string }> = ({ resultFile }
               <>
                 <Box marginTop={1} marginBottom={0}>
                   <Text color={activeGitField === 'linkedRepos' ? POPUP_CONFIG.titleColor : 'white'}>
-                    {activeGitField === 'linkedRepos' ? '▶ ' : '  '}Linked child repos ({selectedLinkedRepos.length}/{availableLinkedRepos.length})
+                    {activeGitField === 'linkedRepos' ? '▶ ' : '  '}Linked nested repos ({selectedLinkedRepos.length}/{availableLinkedRepos.length})
                   </Text>
                 </Box>
                 <Box

--- a/src/hooks/usePaneCreation.ts
+++ b/src/hooks/usePaneCreation.ts
@@ -25,6 +25,7 @@ interface CreateNewPaneOptions {
   baseBranchOverride?: string;
   branchNameOverride?: string;
   goalMode?: boolean;
+  linkedRepoPaths?: string[];
   targetProjectRoot?: string;
   skipAgentSelection?: boolean;
   startPointBranch?: string;
@@ -106,6 +107,7 @@ export default function usePaneCreation({
         baseBranchOverride: options.baseBranchOverride,
         branchNameOverride: options.branchNameOverride,
         goalMode: options.goalMode,
+        linkedRepoPaths: options.linkedRepoPaths,
         projectRoot: options.targetProjectRoot,
         skipAgentSelection: options.skipAgentSelection,
         startPointBranch: options.startPointBranch,
@@ -135,6 +137,7 @@ export default function usePaneCreation({
       baseBranchOverride: options.baseBranchOverride ?? paneInput.baseBranch,
       branchNameOverride: options.branchNameOverride ?? paneInput.branchName,
       goalMode: options.goalMode ?? paneInput.goalMode,
+      linkedRepoPaths: options.linkedRepoPaths ?? paneInput.linkedRepoPaths,
     };
 
     try {
@@ -204,6 +207,7 @@ export default function usePaneCreation({
         baseBranchOverride: paneInput.baseBranch,
         branchNameOverride: paneInput.branchName,
         goalMode: paneInput.goalMode,
+        linkedRepoPaths: paneInput.linkedRepoPaths,
         targetProjectRoot: options.targetProjectRoot,
         startPointBranch: options.startPointBranch,
         mergeTargetChain: options.mergeTargetChain,
@@ -233,6 +237,7 @@ export default function usePaneCreation({
               baseBranchOverride: paneInput.baseBranch,
               branchNameOverride: paneInput.branchName,
               goalMode: paneInput.goalMode,
+              linkedRepoPaths: paneInput.linkedRepoPaths,
               targetProjectRoot: options.targetProjectRoot,
               startPointBranch: options.startPointBranch,
               mergeTargetChain: options.mergeTargetChain,

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -55,7 +55,7 @@ const en: Translations = {
     noPrefix: 'No prefix (default)',
     promptForGitOptionsOnCreate: 'Ask Git Options on Create',
     promptForGitOptionsOnCreateDescription: 'When enabled, new-pane popup asks for optional base branch and branch/worktree name overrides.',
-    linkedRepoPaths: 'Linked Child Repos',
+    linkedRepoPaths: 'Linked Nested Repos',
     linkedRepoPathsDescription: 'Project-scoped relative repo paths (comma or newline separated) that should get matching worktrees in each pane.',
     minPaneWidth: 'Min Pane Width',
     minPaneWidthDescription: 'Global minimum content-pane width in characters used during layout fitting.',

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -55,6 +55,8 @@ const en: Translations = {
     noPrefix: 'No prefix (default)',
     promptForGitOptionsOnCreate: 'Ask Git Options on Create',
     promptForGitOptionsOnCreateDescription: 'When enabled, new-pane popup asks for optional base branch and branch/worktree name overrides.',
+    linkedRepoPaths: 'Linked Child Repos',
+    linkedRepoPathsDescription: 'Project-scoped relative repo paths (comma or newline separated) that should get matching worktrees in each pane.',
     minPaneWidth: 'Min Pane Width',
     minPaneWidthDescription: 'Global minimum content-pane width in characters used during layout fitting.',
     maxPaneWidth: 'Max Pane Width',

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -55,7 +55,7 @@ const ja: Translations = {
     noPrefix: 'プレフィックスなし（デフォルト）',
     promptForGitOptionsOnCreate: '作成時にGitオプションを確認',
     promptForGitOptionsOnCreateDescription: '有効にすると、新しいペインのポップアップで任意のベースブランチとブランチ/ワークツリー名の上書きを確認します。',
-    linkedRepoPaths: '連携子リポジトリ',
+    linkedRepoPaths: '連携ネストリポジトリ',
     linkedRepoPathsDescription: '各ペインで同名ワークツリーを作成する、プロジェクトスコープの相対リポジトリパスです（カンマ区切りまたは改行区切り）。',
     minPaneWidth: '最小ペイン幅',
     minPaneWidthDescription: 'レイアウトフィッティング時に使用されるグローバルなコンテンツペインの最小幅（文字数）です。',

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -55,6 +55,8 @@ const ja: Translations = {
     noPrefix: 'プレフィックスなし（デフォルト）',
     promptForGitOptionsOnCreate: '作成時にGitオプションを確認',
     promptForGitOptionsOnCreateDescription: '有効にすると、新しいペインのポップアップで任意のベースブランチとブランチ/ワークツリー名の上書きを確認します。',
+    linkedRepoPaths: '連携子リポジトリ',
+    linkedRepoPathsDescription: '各ペインで同名ワークツリーを作成する、プロジェクトスコープの相対リポジトリパスです（カンマ区切りまたは改行区切り）。',
     minPaneWidth: '最小ペイン幅',
     minPaneWidthDescription: 'レイアウトフィッティング時に使用されるグローバルなコンテンツペインの最小幅（文字数）です。',
     maxPaneWidth: '最大ペイン幅',

--- a/src/services/PopupManager.ts
+++ b/src/services/PopupManager.ts
@@ -47,6 +47,7 @@ import {
   SIDEBAR_PROJECT_COLOR_THEME_SETTING_KEY,
 } from "../utils/sidebarProjects.js"
 import { resolveProjectColorTheme } from "../utils/paneColors.js"
+import { normalizeLinkedRepoPathsArray } from "../utils/linkedRepoConfig.js"
 import type {
   ReopenWorktreePopupResult,
   ReopenWorktreePopupState,
@@ -353,6 +354,12 @@ export class PopupManager {
     }
     if (typeof candidate.goalMode === "boolean") {
       normalized.goalMode = candidate.goalMode
+    }
+    if (Array.isArray(candidate.linkedRepoPaths)) {
+      const linkedRepoPaths = normalizeLinkedRepoPathsArray(
+        candidate.linkedRepoPaths.filter((value): value is string => typeof value === "string")
+      )
+      normalized.linkedRepoPaths = linkedRepoPaths
     }
 
     return normalized

--- a/src/types.ts
+++ b/src/types.ts
@@ -136,6 +136,8 @@ export interface DmuxSettings {
   branchPrefix?: string;
   // Whether new pane popup should ask for base/branch overrides
   promptForGitOptionsOnCreate?: boolean;
+  // Linked child repositories to manage alongside the root repo (newline/comma-delimited relative paths)
+  linkedRepoPaths?: string;
   // Preferred minimum content pane width in characters
   minPaneWidth?: number;
   // Preferred maximum content pane width in characters
@@ -149,6 +151,7 @@ export interface NewPaneInput {
   baseBranch?: string;
   branchName?: string;
   goalMode?: boolean;
+  linkedRepoPaths?: string[];
 }
 
 export type SettingsScope = 'global' | 'project';

--- a/src/utils/linkedRepoConfig.ts
+++ b/src/utils/linkedRepoConfig.ts
@@ -1,0 +1,169 @@
+import fs from 'fs';
+import path from 'path';
+
+export interface LinkedRepoReference {
+  relativePath: string;
+  repoPath: string;
+}
+
+const LINKED_REPO_SPLIT_PATTERN = /[\n,]+/;
+const LINKED_REPO_DISCOVERY_EXCLUDED_DIRS = new Set([
+  '.dmux',
+  '.git',
+  '.next',
+  '.pnpm',
+  'build',
+  'coverage',
+  'dist',
+  'node_modules',
+  'vendor',
+]);
+
+export function normalizeLinkedRepoPath(input: string): string {
+  return input
+    .trim()
+    .replace(/\\/g, '/')
+    .replace(/^\.\//, '')
+    .replace(/\/+/g, '/')
+    .replace(/\/$/, '');
+}
+
+export function normalizeLinkedRepoPathsArray(values: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const normalized: string[] = [];
+
+  for (const value of values) {
+    const normalizedValue = normalizeLinkedRepoPath(value);
+    if (!normalizedValue || seen.has(normalizedValue)) {
+      continue;
+    }
+    seen.add(normalizedValue);
+    normalized.push(normalizedValue);
+  }
+
+  return normalized;
+}
+
+export function parseLinkedRepoPathsInput(value?: string | null): string[] {
+  if (!value) {
+    return [];
+  }
+
+  return normalizeLinkedRepoPathsArray(value.split(LINKED_REPO_SPLIT_PATTERN));
+}
+
+export function validateLinkedRepoPathsSetting(value?: string | null): string[] {
+  const parsed = parseLinkedRepoPathsInput(value);
+
+  for (const relativePath of parsed) {
+    if (path.isAbsolute(relativePath)) {
+      throw new Error(`Invalid linkedRepoPaths entry: "${relativePath}" must be relative to the project root`);
+    }
+    if (
+      relativePath === '.'
+      || relativePath === '..'
+      || relativePath.startsWith('../')
+      || relativePath.includes('/../')
+    ) {
+      throw new Error(`Invalid linkedRepoPaths entry: "${relativePath}" cannot escape the project root`);
+    }
+  }
+
+  return parsed;
+}
+
+export function normalizeLinkedRepoPathsSetting(value?: string | null): string | undefined {
+  const parsed = validateLinkedRepoPathsSetting(value);
+  return parsed.length > 0 ? parsed.join('\n') : undefined;
+}
+
+export function resolveLinkedRepoReferences(
+  projectRoot: string,
+  linkedRepoPaths?: string[] | string | null
+): LinkedRepoReference[] {
+  const resolvedProjectRoot = path.resolve(projectRoot);
+  const parsed = Array.isArray(linkedRepoPaths)
+    ? normalizeLinkedRepoPathsArray(linkedRepoPaths)
+    : validateLinkedRepoPathsSetting(linkedRepoPaths);
+
+  return parsed.map((relativePath) => {
+    const repoPath = path.resolve(resolvedProjectRoot, relativePath);
+    const relativeToRoot = path.relative(resolvedProjectRoot, repoPath);
+
+    if (
+      relativeToRoot === ''
+      || relativeToRoot === '.'
+      || relativeToRoot === '..'
+      || relativeToRoot.startsWith(`..${path.sep}`)
+    ) {
+      throw new Error(`Linked repo path must point to a child repository: ${relativePath}`);
+    }
+
+    if (!fs.existsSync(repoPath)) {
+      throw new Error(`Linked repo path does not exist: ${relativePath}`);
+    }
+
+    const gitPath = path.join(repoPath, '.git');
+    if (!fs.existsSync(gitPath)) {
+      throw new Error(`Linked repo path is not a git repository: ${relativePath}`);
+    }
+
+    return {
+      relativePath,
+      repoPath,
+    };
+  });
+}
+
+function isGitRepoRoot(dirPath: string): boolean {
+  const gitPath = path.join(dirPath, '.git');
+  if (!fs.existsSync(gitPath)) {
+    return false;
+  }
+
+  try {
+    const stat = fs.statSync(gitPath);
+    return stat.isDirectory() || stat.isFile();
+  } catch {
+    return false;
+  }
+}
+
+export function discoverLinkedRepoPaths(projectRoot: string): string[] {
+  const resolvedProjectRoot = path.resolve(projectRoot);
+  const discovered = new Set<string>();
+
+  const walk = (dirPath: string) => {
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dirPath, { withFileTypes: true });
+    } catch {
+      return;
+    }
+
+    for (const entry of entries) {
+      if (!entry.isDirectory()) {
+        continue;
+      }
+      if (LINKED_REPO_DISCOVERY_EXCLUDED_DIRS.has(entry.name)) {
+        continue;
+      }
+
+      const fullPath = path.join(dirPath, entry.name);
+      if (isGitRepoRoot(fullPath)) {
+        const relativePath = normalizeLinkedRepoPath(
+          path.relative(resolvedProjectRoot, fullPath)
+        );
+        if (relativePath && relativePath !== '.') {
+          discovered.add(relativePath);
+        }
+      }
+
+      walk(fullPath);
+    }
+  };
+
+  walk(resolvedProjectRoot);
+
+  return Array.from(discovered).sort((left, right) => left.localeCompare(right));
+}

--- a/src/utils/linkedWorktrees.ts
+++ b/src/utils/linkedWorktrees.ts
@@ -1,0 +1,648 @@
+import { exec, execSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+import { SettingsManager } from './settingsManager.js';
+import { isValidBranchName } from './git.js';
+import { shellQuote } from './promptStore.js';
+import {
+  parseLinkedRepoPathsInput,
+  resolveLinkedRepoReferences,
+  type LinkedRepoReference,
+} from './linkedRepoConfig.js';
+
+const REMOTE_FALLBACK = 'origin';
+
+export interface WorkspaceRepoReference extends LinkedRepoReference {
+  isRoot: boolean;
+}
+
+interface WorkspaceRepoState extends WorkspaceRepoReference {
+  remoteName: string;
+  hasLocalBranch: boolean;
+  hasRemoteBranch: boolean;
+}
+
+export interface WorkspaceWorktreeTarget extends WorkspaceRepoReference {
+  worktreePath: string;
+  createdWorktree: boolean;
+}
+
+export interface EnsureWorkspaceWorktreesOptions {
+  projectRoot: string;
+  rootWorktreePath: string;
+  branchName: string;
+  linkedRepoPaths?: string[];
+  preferredStartPoint?: string;
+  fallbackStartPointMode?: 'current-head' | 'default-branch';
+}
+
+function runGitText(
+  cwd: string,
+  args: string[],
+  options: { silent?: boolean } = {}
+): string {
+  const command = `git ${args.map((arg) => shellQuote(arg)).join(' ')}`;
+
+  try {
+    return execSync(command, {
+      cwd,
+      encoding: 'utf-8',
+      stdio: 'pipe',
+    }).trim();
+  } catch (error) {
+    if (options.silent) {
+      return '';
+    }
+    throw error;
+  }
+}
+
+async function runGitTextAsync(
+  cwd: string,
+  args: string[],
+  options: { silent?: boolean } = {}
+): Promise<string> {
+  const command = `git ${args.map((arg) => shellQuote(arg)).join(' ')}`;
+
+  return new Promise((resolve, reject) => {
+    exec(
+      command,
+      {
+        cwd,
+        encoding: 'utf-8',
+        maxBuffer: 10 * 1024 * 1024,
+      },
+      (error, stdout) => {
+        if (error) {
+          if (options.silent) {
+            resolve('');
+            return;
+          }
+          reject(error);
+          return;
+        }
+
+        resolve(stdout.trim());
+      }
+    );
+  });
+}
+
+async function runGitAsync(
+  cwd: string,
+  args: string[],
+  options: { silent?: boolean } = {}
+): Promise<void> {
+  await runGitTextAsync(cwd, args, options);
+}
+
+function listLocalBranches(repoPath: string): Set<string> {
+  const output = runGitText(
+    repoPath,
+    ['for-each-ref', '--format=%(refname:short)', 'refs/heads'],
+    { silent: true }
+  );
+
+  return new Set(
+    output
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean)
+  );
+}
+
+async function listLocalBranchesAsync(repoPath: string): Promise<Set<string>> {
+  const output = await runGitTextAsync(
+    repoPath,
+    ['for-each-ref', '--format=%(refname:short)', 'refs/heads'],
+    { silent: true }
+  );
+
+  return new Set(
+    output
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean)
+  );
+}
+
+function getCurrentBranchName(repoPath: string): string {
+  return runGitText(repoPath, ['branch', '--show-current'], { silent: true }) || 'main';
+}
+
+async function getCurrentBranchNameAsync(repoPath: string): Promise<string> {
+  return (await runGitTextAsync(
+    repoPath,
+    ['branch', '--show-current'],
+    { silent: true }
+  )) || 'main';
+}
+
+function getPreferredRemoteName(repoPath: string): string {
+  const upstream = runGitText(
+    repoPath,
+    ['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{upstream}'],
+    { silent: true }
+  );
+  if (upstream.includes('/')) {
+    return upstream.split('/')[0];
+  }
+
+  const currentBranch = getCurrentBranchName(repoPath);
+  if (currentBranch && currentBranch !== 'HEAD') {
+    const configuredRemote = runGitText(
+      repoPath,
+      ['config', `branch.${currentBranch}.remote`],
+      { silent: true }
+    );
+    if (configuredRemote) {
+      return configuredRemote;
+    }
+  }
+
+  return REMOTE_FALLBACK;
+}
+
+async function getPreferredRemoteNameAsync(repoPath: string): Promise<string> {
+  const upstream = await runGitTextAsync(
+    repoPath,
+    ['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{upstream}'],
+    { silent: true }
+  );
+  if (upstream.includes('/')) {
+    return upstream.split('/')[0];
+  }
+
+  const currentBranch = await getCurrentBranchNameAsync(repoPath);
+  if (currentBranch && currentBranch !== 'HEAD') {
+    const configuredRemote = await runGitTextAsync(
+      repoPath,
+      ['config', `branch.${currentBranch}.remote`],
+      { silent: true }
+    );
+    if (configuredRemote) {
+      return configuredRemote;
+    }
+  }
+
+  return REMOTE_FALLBACK;
+}
+
+function listRemoteBranches(repoPath: string, remoteName: string): Set<string> {
+  const output = runGitText(
+    repoPath,
+    ['for-each-ref', '--format=%(refname:short)', `refs/remotes/${remoteName}`],
+    { silent: true }
+  );
+
+  return new Set(
+    output
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .filter((line) => line !== `${remoteName}/HEAD`)
+      .map((line) => (
+        line.startsWith(`${remoteName}/`) ? line.slice(remoteName.length + 1) : line
+      ))
+      .filter(Boolean)
+  );
+}
+
+async function listRemoteBranchesAsync(
+  repoPath: string,
+  remoteName: string
+): Promise<Set<string>> {
+  const output = await runGitTextAsync(
+    repoPath,
+    ['for-each-ref', '--format=%(refname:short)', `refs/remotes/${remoteName}`],
+    { silent: true }
+  );
+
+  return new Set(
+    output
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .filter((line) => line !== `${remoteName}/HEAD`)
+      .map((line) => (
+        line.startsWith(`${remoteName}/`) ? line.slice(remoteName.length + 1) : line
+      ))
+      .filter(Boolean)
+  );
+}
+
+function fetchRemoteBranches(repoPath: string, remoteName: string): void {
+  execSync(`git fetch --prune ${shellQuote(remoteName)}`, {
+    cwd: repoPath,
+    stdio: 'pipe',
+  });
+}
+
+async function fetchRemoteBranchesAsync(repoPath: string, remoteName: string): Promise<void> {
+  await runGitAsync(repoPath, ['fetch', '--prune', remoteName], { silent: true });
+}
+
+async function getBranchUpstreamAsync(repoPath: string, branchName: string): Promise<string> {
+  return runGitTextAsync(
+    repoPath,
+    ['rev-parse', '--abbrev-ref', '--symbolic-full-name', `${branchName}@{upstream}`],
+    { silent: true }
+  );
+}
+
+async function getBranchDivergenceAsync(
+  repoPath: string,
+  localRef: string,
+  remoteRef: string
+): Promise<{ ahead: number; behind: number }> {
+  const output = await runGitTextAsync(
+    repoPath,
+    ['rev-list', '--left-right', '--count', `${localRef}...${remoteRef}`],
+    { silent: true }
+  );
+  const [aheadText = '0', behindText = '0'] = output.split(/\s+/);
+  const ahead = Number.parseInt(aheadText, 10);
+  const behind = Number.parseInt(behindText, 10);
+
+  return {
+    ahead: Number.isFinite(ahead) ? ahead : 0,
+    behind: Number.isFinite(behind) ? behind : 0,
+  };
+}
+
+function getCheckedOutWorktreePath(repoPath: string, branchName: string): string | null {
+  const output = runGitText(
+    repoPath,
+    ['worktree', 'list', '--porcelain'],
+    { silent: true }
+  );
+  if (!output) {
+    return null;
+  }
+
+  let currentWorktree: string | null = null;
+  for (const line of output.split('\n')) {
+    if (line.startsWith('worktree ')) {
+      currentWorktree = line.slice('worktree '.length).trim();
+      continue;
+    }
+
+    if (line === `branch refs/heads/${branchName}`) {
+      return currentWorktree;
+    }
+
+    if (!line.trim()) {
+      currentWorktree = null;
+    }
+  }
+
+  return null;
+}
+
+async function getCheckedOutWorktreePathAsync(
+  repoPath: string,
+  branchName: string
+): Promise<string | null> {
+  const output = await runGitTextAsync(
+    repoPath,
+    ['worktree', 'list', '--porcelain'],
+    { silent: true }
+  );
+  if (!output) {
+    return null;
+  }
+
+  let currentWorktree: string | null = null;
+  for (const line of output.split('\n')) {
+    if (line.startsWith('worktree ')) {
+      currentWorktree = line.slice('worktree '.length).trim();
+      continue;
+    }
+
+    if (line === `branch refs/heads/${branchName}`) {
+      return currentWorktree;
+    }
+
+    if (!line.trim()) {
+      currentWorktree = null;
+    }
+  }
+
+  return null;
+}
+
+async function getMainBranchForRepoAsync(repoPath: string): Promise<string> {
+  const originHead = await runGitTextAsync(
+    repoPath,
+    ['symbolic-ref', 'refs/remotes/origin/HEAD'],
+    { silent: true }
+  );
+  if (originHead.startsWith('refs/remotes/origin/')) {
+    return originHead.slice('refs/remotes/origin/'.length);
+  }
+
+  const hasMain = await runGitTextAsync(
+    repoPath,
+    ['show-ref', '--verify', '--quiet', 'refs/heads/main'],
+    { silent: true }
+  );
+  if (hasMain === '') {
+    // show-ref --quiet emits nothing on success, so verify via sync fallback below.
+    try {
+      execSync('git show-ref --verify --quiet refs/heads/main', {
+        cwd: repoPath,
+        stdio: 'pipe',
+      });
+      return 'main';
+    } catch {
+      // continue
+    }
+  }
+
+  try {
+    execSync('git show-ref --verify --quiet refs/heads/master', {
+      cwd: repoPath,
+      stdio: 'pipe',
+    });
+    return 'master';
+  } catch {
+    return (await getCurrentBranchNameAsync(repoPath)) || 'main';
+  }
+}
+
+async function refExistsAsync(repoPath: string, refName: string): Promise<boolean> {
+  const result = await runGitTextAsync(
+    repoPath,
+    ['rev-parse', '--verify', '--end-of-options', refName],
+    { silent: true }
+  );
+  return result.length > 0;
+}
+
+async function getExistingWorktreeBranchAsync(worktreePath: string): Promise<string | null> {
+  const gitPath = path.join(worktreePath, '.git');
+  if (!fs.existsSync(gitPath)) {
+    return null;
+  }
+
+  return (await getCurrentBranchNameAsync(worktreePath)) || null;
+}
+
+function ensureBranchName(branchName: string): void {
+  if (!isValidBranchName(branchName)) {
+    throw new Error(`Invalid branch name: ${branchName}`);
+  }
+}
+
+function buildWorkspaceRepoStates(
+  projectRoot: string,
+  branchName: string,
+  linkedRepoPaths?: string[]
+): WorkspaceRepoState[] {
+  const rootRepoPath = path.resolve(projectRoot);
+  const repoReferences = [
+    { relativePath: '', repoPath: rootRepoPath },
+    ...resolveLinkedRepoReferences(rootRepoPath, linkedRepoPaths),
+  ];
+
+  return repoReferences.map((reference) => {
+    const remoteName = getPreferredRemoteName(reference.repoPath);
+    const localBranches = listLocalBranches(reference.repoPath);
+    const remoteBranches = listRemoteBranches(reference.repoPath, remoteName);
+
+    return {
+      ...reference,
+      isRoot: reference.relativePath.length === 0,
+      remoteName,
+      hasLocalBranch: localBranches.has(branchName),
+      hasRemoteBranch: remoteBranches.has(branchName),
+    };
+  });
+}
+
+export function getConfiguredLinkedRepoPaths(projectRoot: string): string[] {
+  return parseLinkedRepoPathsInput(
+    new SettingsManager(projectRoot).getSettings().linkedRepoPaths
+  );
+}
+
+export function getWorkspaceRepoReferences(
+  projectRoot: string,
+  linkedRepoPaths?: string[]
+): WorkspaceRepoReference[] {
+  const rootRepoPath = path.resolve(projectRoot);
+
+  return [
+    { isRoot: true, relativePath: '', repoPath: rootRepoPath },
+    ...resolveLinkedRepoReferences(rootRepoPath, linkedRepoPaths).map((reference) => ({
+      ...reference,
+      isRoot: false,
+    })),
+  ];
+}
+
+export function getWorkspaceBranchStates(
+  projectRoot: string,
+  branchName: string,
+  linkedRepoPaths?: string[]
+): Array<{
+  repoPath: string;
+  relativePath: string;
+  remoteName: string;
+  hasLocalBranch: boolean;
+  hasRemoteBranch: boolean;
+}> {
+  return buildWorkspaceRepoStates(projectRoot, branchName, linkedRepoPaths).map((state) => ({
+    repoPath: state.repoPath,
+    relativePath: state.relativePath,
+    remoteName: state.remoteName,
+    hasLocalBranch: state.hasLocalBranch,
+    hasRemoteBranch: state.hasRemoteBranch,
+  }));
+}
+
+export function refreshWorkspaceRemoteBranches(
+  projectRoot: string,
+  branchName: string,
+  linkedRepoPaths?: string[]
+): void {
+  ensureBranchName(branchName);
+  for (const state of buildWorkspaceRepoStates(projectRoot, branchName, linkedRepoPaths)) {
+    fetchRemoteBranches(state.repoPath, state.remoteName);
+  }
+}
+
+async function getWorkspaceBranchStatesAsync(
+  projectRoot: string,
+  branchName: string,
+  linkedRepoPaths?: string[]
+): Promise<WorkspaceRepoState[]> {
+  const repoReferences = getWorkspaceRepoReferences(projectRoot, linkedRepoPaths);
+  const states: WorkspaceRepoState[] = [];
+
+  for (const reference of repoReferences) {
+    const remoteName = await getPreferredRemoteNameAsync(reference.repoPath);
+    const localBranches = await listLocalBranchesAsync(reference.repoPath);
+    const remoteBranches = await listRemoteBranchesAsync(reference.repoPath, remoteName);
+
+    states.push({
+      ...reference,
+      remoteName,
+      hasLocalBranch: localBranches.has(branchName),
+      hasRemoteBranch: remoteBranches.has(branchName),
+    });
+  }
+
+  return states;
+}
+
+function getWorktreePath(rootWorktreePath: string, relativePath: string): string {
+  return relativePath
+    ? path.join(rootWorktreePath, relativePath)
+    : rootWorktreePath;
+}
+
+async function ensureWorktreeAttached(
+  state: WorkspaceRepoState,
+  worktreePath: string,
+  branchName: string,
+  options: {
+    preferredStartPoint?: string;
+    fallbackStartPointMode: 'current-head' | 'default-branch';
+  }
+): Promise<boolean> {
+  ensureBranchName(branchName);
+  await fetchRemoteBranchesAsync(state.repoPath, state.remoteName);
+  await runGitAsync(state.repoPath, ['worktree', 'prune'], { silent: true });
+
+  const existingWorktreeBranch = await getExistingWorktreeBranchAsync(worktreePath);
+  if (existingWorktreeBranch) {
+    if (existingWorktreeBranch !== branchName) {
+      throw new Error(
+        `Existing worktree at ${worktreePath} is on ${existingWorktreeBranch}, expected ${branchName}`
+      );
+    }
+    return false;
+  }
+
+  if (fs.existsSync(worktreePath)) {
+    throw new Error(`Path already exists and is not a git worktree: ${worktreePath}`);
+  }
+
+  state.hasLocalBranch = (await listLocalBranchesAsync(state.repoPath)).has(branchName);
+  state.hasRemoteBranch = (
+    await listRemoteBranchesAsync(state.repoPath, state.remoteName)
+  ).has(branchName);
+
+  const checkedOutWorktreePath = await getCheckedOutWorktreePathAsync(
+    state.repoPath,
+    branchName
+  );
+  if (checkedOutWorktreePath) {
+    if (path.resolve(checkedOutWorktreePath) === path.resolve(worktreePath)) {
+      return false;
+    }
+
+    const repoLabel = state.relativePath || '.';
+    throw new Error(
+      `Branch ${branchName} in ${repoLabel} is already checked out at ${checkedOutWorktreePath}; reopen that worktree instead of recreating it.`
+    );
+  }
+
+  if (state.hasRemoteBranch) {
+    const remoteRef = `${state.remoteName}/${branchName}`;
+
+    if (state.hasLocalBranch) {
+      const upstream = await getBranchUpstreamAsync(state.repoPath, branchName);
+      if (upstream !== remoteRef) {
+        await runGitAsync(
+          state.repoPath,
+          ['branch', `--set-upstream-to=${remoteRef}`, branchName],
+          { silent: true }
+        );
+      }
+
+      const { ahead, behind } = await getBranchDivergenceAsync(
+        state.repoPath,
+        branchName,
+        remoteRef
+      );
+      if (behind > 0 && ahead === 0) {
+        await runGitAsync(state.repoPath, ['branch', '-f', branchName, remoteRef]);
+      } else if (ahead > 0 && behind > 0) {
+        const repoLabel = state.relativePath || '.';
+        throw new Error(
+          `Branch ${branchName} in ${repoLabel} has diverged from ${remoteRef}; refusing to overwrite local commits while opening the workspace.`
+        );
+      }
+    } else {
+      await runGitAsync(
+        state.repoPath,
+        ['branch', '--track', branchName, remoteRef]
+      );
+      state.hasLocalBranch = true;
+    }
+  }
+
+  fs.mkdirSync(path.dirname(worktreePath), { recursive: true });
+
+  if (state.hasLocalBranch) {
+    await runGitAsync(state.repoPath, ['worktree', 'add', worktreePath, branchName]);
+    return true;
+  }
+
+  const preferredStartPoint = options.preferredStartPoint?.trim();
+  const resolvedStartPoint = preferredStartPoint && await refExistsAsync(state.repoPath, preferredStartPoint)
+    ? preferredStartPoint
+    : options.fallbackStartPointMode === 'default-branch'
+      ? await getMainBranchForRepoAsync(state.repoPath)
+      : await getCurrentBranchNameAsync(state.repoPath);
+
+  const args = [
+    'worktree',
+    'add',
+    worktreePath,
+    '-b',
+    branchName,
+    ...(resolvedStartPoint ? [resolvedStartPoint] : []),
+  ];
+
+  await runGitAsync(state.repoPath, args);
+  return true;
+}
+
+export async function ensureWorkspaceWorktrees(
+  options: EnsureWorkspaceWorktreesOptions
+): Promise<WorkspaceWorktreeTarget[]> {
+  const linkedRepoPaths = options.linkedRepoPaths ?? getConfiguredLinkedRepoPaths(options.projectRoot);
+  const repoStates = await getWorkspaceBranchStatesAsync(
+    options.projectRoot,
+    options.branchName,
+    linkedRepoPaths
+  );
+
+  const targets: WorkspaceWorktreeTarget[] = [];
+
+  for (const state of repoStates) {
+    const worktreePath = getWorktreePath(options.rootWorktreePath, state.relativePath);
+    const createdWorktree = await ensureWorktreeAttached(
+      state,
+      worktreePath,
+      options.branchName,
+      {
+        preferredStartPoint: options.preferredStartPoint,
+        fallbackStartPointMode: options.fallbackStartPointMode ?? 'default-branch',
+      }
+    );
+
+    targets.push({
+      isRoot: state.isRoot,
+      repoPath: state.repoPath,
+      relativePath: state.relativePath,
+      worktreePath,
+      createdWorktree,
+    });
+  }
+
+  return targets;
+}

--- a/src/utils/linkedWorktrees.ts
+++ b/src/utils/linkedWorktrees.ts
@@ -502,6 +502,20 @@ function getWorktreePath(rootWorktreePath: string, relativePath: string): string
     : rootWorktreePath;
 }
 
+function isSafeEmptyPlaceholderDir(worktreePath: string): boolean {
+  try {
+    const stat = fs.statSync(worktreePath);
+    if (!stat.isDirectory()) {
+      return false;
+    }
+
+    const entries = fs.readdirSync(worktreePath);
+    return entries.length === 0;
+  } catch {
+    return false;
+  }
+}
+
 async function ensureWorktreeAttached(
   state: WorkspaceRepoState,
   worktreePath: string,
@@ -526,7 +540,11 @@ async function ensureWorktreeAttached(
   }
 
   if (fs.existsSync(worktreePath)) {
-    throw new Error(`Path already exists and is not a git worktree: ${worktreePath}`);
+    if (isSafeEmptyPlaceholderDir(worktreePath)) {
+      fs.rmdirSync(worktreePath);
+    } else {
+      throw new Error(`Path already exists and is not a git worktree: ${worktreePath}`);
+    }
   }
 
   state.hasLocalBranch = (await listLocalBranchesAsync(state.repoPath)).has(branchName);

--- a/src/utils/mergeValidation.ts
+++ b/src/utils/mergeValidation.ts
@@ -7,6 +7,8 @@
 import { execSync } from 'child_process';
 import { LogService } from '../services/LogService.js';
 import { getCurrentBranch as getCurrentBranchUtil } from './git.js';
+import { normalizeLinkedRepoPathsArray, normalizeLinkedRepoPath } from './linkedRepoConfig.js';
+import { readWorktreeMetadata } from './worktreeMetadata.js';
 
 export interface MergeValidationResult {
   canMerge: boolean;
@@ -28,6 +30,10 @@ export interface GitStatus {
   summary: string;
 }
 
+export interface GitStatusOptions {
+  ignoredRelativePaths?: string[];
+}
+
 const DMUX_HOOK_SCAFFOLD_PATHS = new Set([
   '.dmux-hooks',
   '.dmux-hooks/',
@@ -36,6 +42,13 @@ const DMUX_HOOK_SCAFFOLD_PATHS = new Set([
   '.dmux-hooks/README.md',
   '.dmux-hooks/examples',
   '.dmux-hooks/examples/',
+]);
+
+const AGENT_STATE_SCAFFOLD_PATHS = new Set([
+  '.claude',
+  '.claude/',
+  '.codex',
+  '.codex/',
 ]);
 
 function parseGitStatusLine(line: string): { statusCode: string; filename: string } {
@@ -49,7 +62,47 @@ function parseGitStatusLine(line: string): { statusCode: string; filename: strin
   };
 }
 
-function shouldIgnoreGitStatusEntry(statusCode: string, filename: string): boolean {
+function normalizeGitStatusPath(filename: string): string {
+  return normalizeLinkedRepoPath(filename.replace(/\\/g, '/'));
+}
+
+function isIgnoredWorkspacePath(
+  filename: string,
+  ignoredRelativePaths: readonly string[]
+): boolean {
+  if (ignoredRelativePaths.length === 0) {
+    return false;
+  }
+
+  const normalizedFilename = normalizeGitStatusPath(filename);
+  if (!normalizedFilename) {
+    return false;
+  }
+
+  return ignoredRelativePaths.some((relativePath) => (
+    normalizedFilename === relativePath
+    || normalizedFilename.startsWith(`${relativePath}/`)
+  ));
+}
+
+function getIgnoredRelativePaths(
+  repoPath: string,
+  options?: GitStatusOptions
+): string[] {
+  const metadataPaths = readWorktreeMetadata(repoPath)?.linkedRepoPaths ?? [];
+  const explicitPaths = options?.ignoredRelativePaths ?? [];
+
+  return normalizeLinkedRepoPathsArray([
+    ...metadataPaths,
+    ...explicitPaths,
+  ]);
+}
+
+function shouldIgnoreGitStatusEntry(
+  statusCode: string,
+  filename: string,
+  ignoredRelativePaths: readonly string[]
+): boolean {
   if (
     filename === '.dmux'
     || filename === '.dmux/'
@@ -58,12 +111,19 @@ function shouldIgnoreGitStatusEntry(statusCode: string, filename: string): boole
     return true;
   }
 
+  if (isIgnoredWorkspacePath(filename, ignoredRelativePaths)) {
+    return true;
+  }
+
   if (statusCode !== '??') {
     return false;
   }
 
   return (
-    DMUX_HOOK_SCAFFOLD_PATHS.has(filename)
+    AGENT_STATE_SCAFFOLD_PATHS.has(filename)
+    || filename.startsWith('.claude/')
+    || filename.startsWith('.codex/')
+    || DMUX_HOOK_SCAFFOLD_PATHS.has(filename)
     || filename.startsWith('.dmux-hooks/examples/')
   );
 }
@@ -71,9 +131,10 @@ function shouldIgnoreGitStatusEntry(statusCode: string, filename: string): boole
 /**
  * Get git status for a repository
  */
-export function getGitStatus(repoPath: string): GitStatus {
+export function getGitStatus(repoPath: string, options: GitStatusOptions = {}): GitStatus {
   try {
     LogService.getInstance().info(`Getting git status for: ${repoPath}`, 'mergeValidation');
+    const ignoredRelativePaths = getIgnoredRelativePaths(repoPath, options);
     const statusOutput = execSync('git status --porcelain', {
       cwd: repoPath,
       encoding: 'utf-8',
@@ -95,7 +156,11 @@ export function getGitStatus(repoPath: string): GitStatus {
 
     const visibleEntries = entries
       .filter(({ statusCode, filename, line }) => {
-        const shouldIgnore = shouldIgnoreGitStatusEntry(statusCode, filename);
+        const shouldIgnore = shouldIgnoreGitStatusEntry(
+          statusCode,
+          filename,
+          ignoredRelativePaths
+        );
         if (shouldIgnore) {
           LogService.getInstance().info(
             `Ignoring git status entry: "${line}"`,
@@ -252,12 +317,15 @@ export function validateMerge(
   worktreeBranch: string
 ): MergeValidationResult {
   const issues: MergeIssue[] = [];
+  const linkedRepoPaths = readWorktreeMetadata(worktreePath)?.linkedRepoPaths ?? [];
 
   // Get current main branch
   const mainBranch = getCurrentBranch(mainRepoPath);
 
   // Check if main branch is clean
-  const mainStatus = getGitStatus(mainRepoPath);
+  const mainStatus = getGitStatus(mainRepoPath, {
+    ignoredRelativePaths: linkedRepoPaths,
+  });
   if (mainStatus.hasChanges) {
     issues.push({
       type: 'main_dirty',
@@ -268,7 +336,9 @@ export function validateMerge(
   }
 
   // Check if worktree has uncommitted changes
-  const worktreeStatus = getGitStatus(worktreePath);
+  const worktreeStatus = getGitStatus(worktreePath, {
+    ignoredRelativePaths: linkedRepoPaths,
+  });
   LogService.getInstance().info(
     `Worktree status: hasChanges=${worktreeStatus.hasChanges}, files=${JSON.stringify(worktreeStatus.files)}`,
     'mergeValidation'

--- a/src/utils/paneBootstrapConfig.ts
+++ b/src/utils/paneBootstrapConfig.ts
@@ -25,6 +25,7 @@ export interface PaneBootstrapConfig {
     displayName?: string;
     branchName?: string;
     mergeTargetChain?: DmuxPane['mergeTargetChain'];
+    linkedRepoPaths?: string[];
   };
   hookExtraEnv?: Record<string, string>;
 }

--- a/src/utils/paneBootstrapRunner.ts
+++ b/src/utils/paneBootstrapRunner.ts
@@ -29,6 +29,7 @@ import {
 } from './promptStore.js';
 import { triggerHookWithProgress, initializeHooksDirectory } from './hooks.js';
 import { writeWorktreeMetadata } from './worktreeMetadata.js';
+import { ensureWorkspaceWorktrees, type WorkspaceWorktreeTarget } from './linkedWorktrees.js';
 import { ensureGeminiFolderTrusted } from './geminiTrust.js';
 import {
   buildCodexHookedCommand,
@@ -454,18 +455,10 @@ async function commandSucceeds(command: string, args: string[], cwd: string): Pr
   return result.code === 0;
 }
 
-async function prepareWorktree(config: PaneBootstrapConfig): Promise<void> {
-  if (config.existingWorktree) {
-    if (!fs.existsSync(path.join(config.worktreePath, '.git'))) {
-      throw new Error(`Existing worktree not found at ${config.worktreePath}`);
-    }
-    return;
+async function prepareWorktree(config: PaneBootstrapConfig): Promise<WorkspaceWorktreeTarget[]> {
+  if (config.existingWorktree && !fs.existsSync(path.join(config.worktreePath, '.git'))) {
+    throw new Error(`Existing worktree not found at ${config.worktreePath}`);
   }
-
-  await runCommand('git', ['worktree', 'prune'], {
-    cwd: config.projectRoot,
-    allowFailure: true,
-  });
 
   if (config.resolvedStartPoint) {
     const startPointExists = await commandSucceeds(
@@ -478,33 +471,14 @@ async function prepareWorktree(config: PaneBootstrapConfig): Promise<void> {
     }
   }
 
-  if (fs.existsSync(config.worktreePath)) {
-    if (fs.existsSync(path.join(config.worktreePath, '.git'))) {
-      return;
-    }
-    throw new Error(`Path already exists and is not a git worktree: ${config.worktreePath}`);
-  }
-
-  fs.mkdirSync(path.dirname(config.worktreePath), { recursive: true });
-
-  const branchExists = await commandSucceeds(
-    'git',
-    ['show-ref', '--verify', '--quiet', `refs/heads/${config.branchName}`],
-    config.projectRoot
-  );
-
-  const args = branchExists
-    ? ['worktree', 'add', config.worktreePath, config.branchName]
-    : [
-        'worktree',
-        'add',
-        config.worktreePath,
-        '-b',
-        config.branchName,
-        ...(config.resolvedStartPoint ? [config.resolvedStartPoint] : []),
-      ];
-
-  await runCommand('git', args, { cwd: config.projectRoot });
+  return ensureWorkspaceWorktrees({
+    projectRoot: config.projectRoot,
+    rootWorktreePath: config.worktreePath,
+    branchName: config.branchName,
+    linkedRepoPaths: config.metadata.linkedRepoPaths,
+    preferredStartPoint: config.resolvedStartPoint,
+    fallbackStartPointMode: 'current-head',
+  });
 }
 
 async function sendInteractivePrompt(config: PaneBootstrapConfig): Promise<void> {
@@ -545,6 +519,54 @@ async function sendInteractivePrompt(config: PaneBootstrapConfig): Promise<void>
       await tmuxService.deleteBuffer(bufferName);
     } catch {
       // Best-effort cleanup.
+    }
+  }
+}
+
+function writeLinkedWorktreeMetadata(
+  config: PaneBootstrapConfig,
+  targets: WorkspaceWorktreeTarget[]
+): void {
+  for (const target of targets) {
+    if (target.isRoot) {
+      continue;
+    }
+
+    writeWorktreeMetadata(target.worktreePath, {
+      branchName: config.branchName !== config.slug ? config.branchName : undefined,
+    });
+  }
+}
+
+async function runChildWorktreeHooks(
+  config: PaneBootstrapConfig,
+  targets: WorkspaceWorktreeTarget[]
+): Promise<void> {
+  for (const target of targets) {
+    if (target.isRoot) {
+      continue;
+    }
+
+    const hookResult = await triggerHookWithProgress(
+      'worktree_created',
+      target.repoPath,
+      undefined,
+      {
+        ...config.hookExtraEnv,
+        DMUX_PROGRESS: '1',
+        DMUX_STATUS_PREFIX: 'DMUX_STATUS:',
+        DMUX_SLUG: config.slug,
+        DMUX_PROMPT: config.prompt || 'No initial prompt',
+        DMUX_AGENT: config.agent || 'unknown',
+        DMUX_WORKTREE_PATH: target.worktreePath,
+        DMUX_BRANCH: config.branchName,
+      },
+      (event) => appendProgressLine(event.line, event.stream),
+      BOOTSTRAP_HOOK_TIMEOUT_MS
+    );
+
+    if (!hookResult.success) {
+      throw new Error(hookResult.error || 'linked worktree_created hook failed');
     }
   }
 }
@@ -693,11 +715,14 @@ async function main(): Promise<number> {
 
   try {
     setStep(config, steps, 'worktree', 'active');
-    await prepareWorktree(config);
-    setStep(config, steps, 'worktree', 'done', config.worktreePath);
+    const workspaceTargets = await prepareWorktree(config);
+    setStep(config, steps, 'worktree', 'done', workspaceTargets.length > 1
+      ? `${config.worktreePath} (+${workspaceTargets.length - 1} linked)`
+      : config.worktreePath);
 
     setStep(config, steps, 'metadata', 'active');
     writeWorktreeMetadata(config.worktreePath, config.metadata);
+    writeLinkedWorktreeMetadata(config, workspaceTargets);
     setStep(config, steps, 'metadata', 'done');
 
     if (config.isHooksEditingSession) {
@@ -722,6 +747,11 @@ async function main(): Promise<number> {
     if (!hookResult.success) {
       throw new Error(hookResult.error || 'worktree_created hook failed');
     }
+
+    if (!config.existingWorktree) {
+      await runChildWorktreeHooks(config, workspaceTargets);
+    }
+
     setStep(config, steps, 'worktree-hook', 'done');
 
     if (config.agent === 'gemini') {

--- a/src/utils/paneCreation.ts
+++ b/src/utils/paneCreation.ts
@@ -23,6 +23,7 @@ import { shellQuote } from './promptStore.js';
 import { isValidBranchName, isValidFullBranchName } from './git.js';
 import { resolvePaneNaming } from './paneNaming.js';
 import { readWorktreeMetadata } from './worktreeMetadata.js';
+import { parseLinkedRepoPathsInput } from './linkedRepoConfig.js';
 import { resolveProjectColorTheme } from './paneColors.js';
 import type { SidebarProject } from '../types.js';
 import { StateManager } from '../shared/StateManager.js';
@@ -39,6 +40,7 @@ export interface CreatePaneOptions {
   baseBranchOverride?: string;
   branchNameOverride?: string;
   goalMode?: boolean;
+  linkedRepoPaths?: string[];
   existingWorktree?: {
     slug: string;
     worktreePath: string;
@@ -165,6 +167,7 @@ export async function createPane(
     baseBranchOverride,
     branchNameOverride,
     goalMode: goalModeOverride,
+    linkedRepoPaths: linkedRepoPathsOverride,
     existingWorktree,
     startPointBranch,
     mergeTargetChain,
@@ -213,6 +216,13 @@ export async function createPane(
   const existingWorktreeMetadata = existingWorktree
     ? readWorktreeMetadata(existingWorktree.worktreePath)
     : null;
+  const linkedRepoPaths = existingWorktreeMetadata?.linkedRepoPaths
+    ?? (linkedRepoPathsOverride !== undefined
+      ? linkedRepoPathsOverride
+      : parseLinkedRepoPathsInput(settings.linkedRepoPaths));
+  const shouldPersistLinkedRepoPaths = existingWorktreeMetadata?.linkedRepoPaths !== undefined
+    || linkedRepoPathsOverride !== undefined
+    || linkedRepoPaths.length > 0;
 
   const sessionProjectRoot = optionsSessionProjectRoot
     || (optionsSessionConfigPath ? path.dirname(path.dirname(optionsSessionConfigPath)) : projectRoot);
@@ -507,6 +517,7 @@ export async function createPane(
       displayName: existingWorktreeMetadata?.displayName,
       branchName: branchName !== slug ? branchName : undefined,
       mergeTargetChain,
+      linkedRepoPaths: shouldPersistLinkedRepoPaths ? linkedRepoPaths : undefined,
     },
     hookExtraEnv,
   };

--- a/src/utils/reopenWorktree.ts
+++ b/src/utils/reopenWorktree.ts
@@ -21,13 +21,14 @@ import { ensureGeminiFolderTrusted } from './geminiTrust.js';
 import { SettingsManager } from './settingsManager.js';
 import { filterEnabledAgents, getInstalledAgents } from './agentDetection.js';
 import { getCurrentBranch } from './git.js';
-import { readWorktreeMetadata } from './worktreeMetadata.js';
+import { readWorktreeMetadata, writeWorktreeMetadata } from './worktreeMetadata.js';
 import {
   buildCodexHookedCommand,
   installCodexPaneHooks,
 } from './codexHooks.js';
 import { installClaudePaneHooks } from './claudeHooks.js';
 import { resolveProjectColorTheme } from './paneColors.js';
+import { ensureWorkspaceWorktrees, getConfiguredLinkedRepoPaths } from './linkedWorktrees.js';
 import type { SidebarProject } from '../types.js';
 
 export interface ReopenWorktreeOptions {
@@ -63,6 +64,7 @@ export async function reopenWorktree(
   const paneProjectName = path.basename(projectRoot);
   const settings = new SettingsManager(projectRoot).getSettings();
   const metadata = readWorktreeMetadata(worktreePath);
+  const linkedRepoPaths = metadata?.linkedRepoPaths ?? getConfiguredLinkedRepoPaths(projectRoot);
   const sessionProjectRoot = optionsSessionProjectRoot
     || (optionsSessionConfigPath ? path.dirname(path.dirname(optionsSessionConfigPath)) : projectRoot);
 
@@ -160,6 +162,26 @@ export async function reopenWorktree(
   // Wait for CD to complete
   await new Promise((resolve) => setTimeout(resolve, 300));
 
+  const currentBranch = metadata?.branchName || getCurrentBranch(worktreePath);
+
+  const workspaceTargets = linkedRepoPaths.length > 0
+    ? await ensureWorkspaceWorktrees({
+        projectRoot,
+        rootWorktreePath: worktreePath,
+        branchName: currentBranch,
+        linkedRepoPaths,
+        fallbackStartPointMode: 'current-head',
+      })
+    : [];
+
+  for (const target of workspaceTargets) {
+    if (!target.isRoot && target.createdWorktree) {
+      writeWorktreeMetadata(target.worktreePath, {
+        branchName: currentBranch !== slug ? currentBranch : undefined,
+      });
+    }
+  }
+
   // Detect which agent to use - prefer stored metadata, then fall back to enabled/installed order.
   const installedAgents = await getInstalledAgents();
   const enabledAgents = filterEnabledAgents(installedAgents, settings.enabledAgents);
@@ -229,8 +251,6 @@ export async function reopenWorktree(
   await tmuxService.selectPane(paneInfo);
 
   // Create the pane object
-  const currentBranch = getCurrentBranch(worktreePath);
-
   const newPane: DmuxPane = {
     id: dmuxPaneId,
     slug,

--- a/src/utils/resumeBranches.ts
+++ b/src/utils/resumeBranches.ts
@@ -9,6 +9,7 @@ import { getOrphanedWorktrees, isValidBranchName } from './git.js';
 import { createPane } from './paneCreation.js';
 import { shellQuote } from './promptStore.js';
 import { SettingsManager } from './settingsManager.js';
+import { getConfiguredLinkedRepoPaths, getWorkspaceRepoReferences } from './linkedWorktrees.js';
 import { writeWorktreeMetadata } from './worktreeMetadata.js';
 
 const REMOTE_FALLBACK = 'origin';
@@ -155,36 +156,10 @@ function isGitRepoRoot(dirPath: string): boolean {
 }
 
 function discoverWorkspaceRepos(projectRoot: string): string[] {
-  const discovered = new Set<string>([projectRoot]);
-
-  const walk = (dirPath: string) => {
-    let entries: fs.Dirent[];
-    try {
-      entries = fs.readdirSync(dirPath, { withFileTypes: true });
-    } catch {
-      return;
-    }
-
-    for (const entry of entries) {
-      if (!entry.isDirectory()) {
-        continue;
-      }
-      if (RESUME_SCAN_EXCLUDED_DIRS.has(entry.name)) {
-        continue;
-      }
-
-      const fullPath = path.join(dirPath, entry.name);
-      if (isGitRepoRoot(fullPath)) {
-        discovered.add(fullPath);
-      }
-
-      walk(fullPath);
-    }
-  };
-
-  walk(projectRoot);
-
-  return Array.from(discovered).sort((left, right) => left.length - right.length);
+  return getWorkspaceRepoReferences(
+    projectRoot,
+    getConfiguredLinkedRepoPaths(projectRoot)
+  ).map((reference) => reference.repoPath);
 }
 
 function listLocalBranches(repoPath: string): Set<string> {
@@ -961,6 +936,7 @@ export async function resumeBranchWorkspace(
     sessionProjectRoot,
   } = options;
 
+  const linkedRepoPaths = getConfiguredLinkedRepoPaths(projectRoot);
   const workspaceStates = await getWorkspaceBranchStatesAsync(projectRoot, branchName);
   const slug = getAvailableSlug(branchName, projectRoot, existingPanes);
   const rootWorktreePath = path.join(projectRoot, '.dmux', 'worktrees', slug);
@@ -986,6 +962,9 @@ export async function resumeBranchWorkspace(
       ...(agent && !state.relativePath ? { agent } : {}),
       permissionMode: state.relativePath ? undefined : settings.permissionMode,
       branchName: branchName !== slug ? branchName : undefined,
+      linkedRepoPaths: !state.relativePath && linkedRepoPaths.length > 0
+        ? linkedRepoPaths
+        : undefined,
     });
   }
 

--- a/src/utils/settingsManager.ts
+++ b/src/utils/settingsManager.ts
@@ -403,7 +403,7 @@ export const SETTING_DEFINITIONS: SettingDefinition[] = [
   },
   {
     key: 'linkedRepoPaths',
-    label: 'Linked Child Repos',
+    label: 'Linked Nested Repos',
     description: 'Project-scoped relative repo paths (comma or newline separated) that should get matching worktrees in each pane.',
     type: 'text',
     scopeBehavior: 'project',

--- a/src/utils/settingsManager.ts
+++ b/src/utils/settingsManager.ts
@@ -13,6 +13,7 @@ import {
   SHIFT_MAX_PANE_WIDTH_STEP,
 } from '../constants/layout.js';
 import { isValidBranchName } from './git.js';
+import { normalizeLinkedRepoPathsSetting } from './linkedRepoConfig.js';
 import {
   getAgentDefinitions,
   getDefaultEnabledAgents,
@@ -134,6 +135,17 @@ function sanitizeLoadedSettings(value: unknown): DmuxSettings {
     && (parsed.branchPrefix === '' || isValidBranchName(parsed.branchPrefix))
   ) {
     sanitized.branchPrefix = parsed.branchPrefix;
+  }
+
+  if (typeof parsed.linkedRepoPaths === 'string') {
+    try {
+      const normalizedLinkedRepoPaths = normalizeLinkedRepoPathsSetting(parsed.linkedRepoPaths);
+      if (normalizedLinkedRepoPaths !== undefined) {
+        sanitized.linkedRepoPaths = normalizedLinkedRepoPaths;
+      }
+    } catch {
+      // Ignore invalid persisted linked repo settings.
+    }
   }
 
   if (isValidMinPaneWidth(parsed.minPaneWidth)) {
@@ -262,6 +274,10 @@ const LOCALIZED_SETTING_TRANSLATIONS: Partial<
     label: 'settings.promptForGitOptionsOnCreate',
     description: 'settings.promptForGitOptionsOnCreateDescription',
   },
+  linkedRepoPaths: {
+    label: 'settings.linkedRepoPaths',
+    description: 'settings.linkedRepoPathsDescription',
+  },
   minPaneWidth: {
     label: 'settings.minPaneWidth',
     description: 'settings.minPaneWidthDescription',
@@ -384,6 +400,13 @@ export const SETTING_DEFINITIONS: SettingDefinition[] = [
     label: 'Ask Git Options on Create',
     description: 'When enabled, new-pane popup asks for optional base branch and branch/worktree name overrides.',
     type: 'boolean',
+  },
+  {
+    key: 'linkedRepoPaths',
+    label: 'Linked Child Repos',
+    description: 'Project-scoped relative repo paths (comma or newline separated) that should get matching worktrees in each pane.',
+    type: 'text',
+    scopeBehavior: 'project',
   },
   {
     key: 'minPaneWidth',
@@ -571,6 +594,9 @@ export class SettingsManager {
         throw new Error(`Invalid ${key}: contains characters not allowed in git branch names`);
       }
     }
+    if (key === 'linkedRepoPaths' && typeof value === 'string') {
+      value = normalizeLinkedRepoPathsSetting(value) as DmuxSettings[K];
+    }
     if (key === 'permissionMode' && typeof value === 'string' && !isPermissionMode(value)) {
       throw new Error(`Invalid permissionMode: "${value}"`);
     }
@@ -688,6 +714,9 @@ export class SettingsManager {
     }
     if (typeof settings.branchPrefix === 'string' && settings.branchPrefix !== '' && !isValidBranchName(settings.branchPrefix)) {
       throw new Error('Invalid branchPrefix: contains characters not allowed in git branch names');
+    }
+    if (typeof settings.linkedRepoPaths === 'string') {
+      settings.linkedRepoPaths = normalizeLinkedRepoPathsSetting(settings.linkedRepoPaths);
     }
     if (settings.minPaneWidth !== undefined && !isValidMinPaneWidth(settings.minPaneWidth)) {
       throw new Error(

--- a/src/utils/worktreeMetadata.ts
+++ b/src/utils/worktreeMetadata.ts
@@ -8,6 +8,7 @@ import {
 } from './agentLaunch.js';
 import { atomicWriteJsonSync } from './atomicWrite.js';
 import { sanitizePaneDisplayName } from './paneTitle.js';
+import { validateLinkedRepoPathsSetting } from './linkedRepoConfig.js';
 
 export interface WorktreeMetadata {
   agent?: AgentName;
@@ -16,6 +17,7 @@ export interface WorktreeMetadata {
   displayName?: string;
   branchName?: string;
   mergeTargetChain?: MergeTargetReference[];
+  linkedRepoPaths?: string[];
 }
 
 const METADATA_DIR = '.dmux';
@@ -48,6 +50,22 @@ function isMergeTargetReference(value: unknown): value is MergeTargetReference {
   }
 
   return true;
+}
+
+function normalizeLinkedRepoPaths(linkedRepoPaths: unknown): string[] | undefined {
+  if (!Array.isArray(linkedRepoPaths)) return undefined;
+
+  const normalized = linkedRepoPaths
+    .filter((entry): entry is string => typeof entry === 'string')
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+
+  try {
+    const validated = validateLinkedRepoPathsSetting(normalized.join('\n'));
+    return validated;
+  } catch {
+    return undefined;
+  }
 }
 
 function normalizeMergeTargetChain(
@@ -109,6 +127,11 @@ export function readWorktreeMetadata(worktreePath: string): WorktreeMetadata | n
       metadata.mergeTargetChain = mergeTargetChain;
     }
 
+    const linkedRepoPaths = normalizeLinkedRepoPaths(parsed.linkedRepoPaths);
+    if (linkedRepoPaths) {
+      metadata.linkedRepoPaths = linkedRepoPaths;
+    }
+
     return metadata;
   } catch {
     return null;
@@ -125,6 +148,9 @@ export function writeWorktreeMetadata(
     ...metadata,
     displayName: metadata.displayName
       ? sanitizePaneDisplayName(metadata.displayName)
+      : undefined,
+    linkedRepoPaths: metadata.linkedRepoPaths !== undefined
+      ? validateLinkedRepoPathsSetting(metadata.linkedRepoPaths.join('\n'))
       : undefined,
   });
 }


### PR DESCRIPTION

  ## Summary

 This PR adds support for linked nested repositories
  inside a pane workspace.

  Previously, dmux only managed the root repository for
  a pane worktree. With this change, a pane can also
  carry selected project-relative nested git
  repositories through the same lifecycle as the root
  repo, so create, reopen, resume, bootstrap, and
  cleanup stay aligned.

  This is different from `Create Child Worktree`: that
  feature creates a new pane/worktree from an existing
  pane branch, while this PR lets a single pane
  workspace manage multiple related repositories
  together.


  ## What changed

  - add pane-level linked child repo selection in the new pane flow
  - persist linked repo metadata in worktree state
  - carry linked repos through reopen and resume flows
  - keep linked repos aligned during bootstrap and cleanup
  - add coverage for linked repo config, metadata, reopen/resume flows, and pane
  lifecycle integration

  ## Testing

  - `pnpm run typecheck`
  - targeted tests for linked repo lifecycle behavior
