### PR TITLE
ci: run the existing test suite on push and PR

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,31 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  test:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.14.0'
+          cache: 'pnpm'
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      # The e2e specs gate themselves behind DMUX_E2E=1 and stay skipped here;
+      # they drive a real tmux server, which CI has no terminal for.
+      - name: Unit tests
+        run: pnpm test

--- a/__tests__/integration/gitOperations.test.ts
+++ b/__tests__/integration/gitOperations.test.ts
@@ -472,7 +472,11 @@ index abc123..def456 100644
     });
 
     it('should generate commit message from AI', async () => {
-      // Mock OpenRouter API
+      // callOpenRouter bails out before fetch when the key is absent, so without
+      // this the assertion silently measures the callClaudeCode fallback instead.
+      const previousKey = process.env.OPENROUTER_API_KEY;
+      process.env.OPENROUTER_API_KEY = 'test-key';
+
       global.fetch = vi.fn(() =>
         Promise.resolve({
           ok: true,
@@ -483,24 +487,43 @@ index abc123..def456 100644
         } as Response)
       );
 
-      const { generateCommitMessage } = await import('../../src/utils/aiMerge.js');
+      try {
+        const { generateCommitMessage } = await import('../../src/utils/aiMerge.js');
 
-      const message = await generateCommitMessage('diff content here', '/test');
+        const message = await generateCommitMessage('/test');
 
-      expect(message).toContain('feat:');
-      expect(message).toContain('authentication');
+        expect(message).toContain('feat:');
+        expect(message).toContain('authentication');
+      } finally {
+        if (previousKey === undefined) {
+          delete process.env.OPENROUTER_API_KEY;
+        } else {
+          process.env.OPENROUTER_API_KEY = previousKey;
+        }
+      }
     });
 
     it('should fallback to manual commit when AI fails', async () => {
+      const previousKey = process.env.OPENROUTER_API_KEY;
+      process.env.OPENROUTER_API_KEY = 'test-key';
+
       // Mock API failure
       global.fetch = vi.fn(() => Promise.reject(new Error('API timeout')));
 
-      const { generateCommitMessage } = await import('../../src/utils/aiMerge.js');
+      try {
+        const { generateCommitMessage } = await import('../../src/utils/aiMerge.js');
 
-      const message = await generateCommitMessage('diff content', '/test');
+        const message = await generateCommitMessage('/test');
 
-      // Should return a fallback message or empty string
-      expect(message).toBeDefined();
+        // Should return a fallback message or null
+        expect(message).toBeDefined();
+      } finally {
+        if (previousKey === undefined) {
+          delete process.env.OPENROUTER_API_KEY;
+        } else {
+          process.env.OPENROUTER_API_KEY = previousKey;
+        }
+      }
     });
   });
 


### PR DESCRIPTION
The repo has 92 test files and `vitest.config.ts`, but `.github/workflows/` only contains `publish.yml` — nothing runs them. Pull requests therefore land with no checks at all (#102 is currently sitting at zero).

This adds a `Test` workflow mirroring the conventions already in `publish.yml` (macos-latest, `pnpm/action-setup@v4`, Node 22.14.0 with pnpm cache, `--frozen-lockfile`) and running `pnpm typecheck` then `pnpm test`. The e2e specs gate themselves behind `DMUX_E2E=1` and stay skipped, since they drive a real tmux server.

### One test had to be fixed first

`main` is not currently green. `__tests__/integration/gitOperations.test.ts` calls:

```ts
await generateCommitMessage('diff content here', '/test');
```

but the function takes a single argument (`src/utils/aiMerge.ts:150`), which is how production callers use it (`mergePopup.tsx:117`, `commitMessageHandler.ts:25`). The first argument was being used as `repoPath`.

The assertion also never reached the mocked `fetch`: `callOpenRouter` returns `null` when `OPENROUTER_API_KEY` is unset (`aiMerge.ts:36-37`), so the flow fell through to `callClaudeCode`, whose `execSync` is mocked in that file — the test was asserting against `'[main abc123] Test commit'`. The fix passes the real signature and sets a dummy key around the call so the OpenRouter branch is actually exercised, restoring the previous value afterwards.

Verified locally: `109 passed | 1 skipped`, 652 tests, `pnpm typecheck` clean.

### Unrelated finding

`src/components/panes/MergePane.tsx:143` calls `generateCommitMessage()` with no argument at all, so `repoPath` is `undefined`. Left alone here to keep this PR reviewable — happy to file it separately.