### PR TITLE
fix: clean up on SIGHUP

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1458,6 +1458,12 @@ class Dmux {
     process.on('SIGTERM', () => {
       cleanTerminalExit('SIGTERM');
     });
+    // Closing the terminal window sends SIGHUP. Without this the process dies on
+    // the default action, so the session keeps tmux hooks aimed at a PID that is
+    // about to be recycled, and the pane is left in mouse-reporting mode.
+    process.on('SIGHUP', () => {
+      cleanTerminalExit('SIGHUP');
+    });
 
     // Handle SIGUSR2 for pane split detection
     // This signal is sent by tmux hook when a new pane is created


### PR DESCRIPTION
Closing the terminal window sends `SIGHUP`. `setupGlobalSignalHandlers` wires `SIGINT` and `SIGTERM` to `cleanTerminalExit` (`src/index.ts:1455-1460`) but never `SIGHUP`, so the process dies on the default action and the teardown is skipped entirely.

Two things leak as a result, both of which I hit in practice:

- The session keeps its tmux hooks. `tmux show-hooks` still shows `kill -USR1 <pid>` / `kill -USR2 <pid>` aimed at a dead PID. PIDs wrap, so an unrelated process later inherits that PID and gets signalled on every resize.
- The pane is left in mouse-reporting mode. With a plain shell now running there, every mouse movement is delivered as text: `zsh: command not found: 73M64`.

The fix is one handler — `cleanTerminalExit` already removes the hooks (`src/index.ts:1372-1392`) and writes `MOUSE_REPORTING_DISABLE` (`:1414`); `SIGHUP` simply never reached it. No new teardown code.

### Test status

`pnpm typecheck` clean. The suite shows `1 failed | 108 passed | 1 skipped` both before and after this change — the failure is the pre-existing stale `generateCommitMessage` test, fixed separately in #103.

While running the suite repeatedly I also saw `__tests__/cleanTextInput.wrap.interactions.test.tsx > wraps the full word exactly when overflow occurs` fail once in three runs (`expected 1 to be greater than 1`) on an otherwise unchanged tree, on a heavily loaded machine. It looks load-sensitive rather than related to this change; flagging it rather than touching it here.