### PR TITLE
fix: handle --version and --help before starting a session

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1484,6 +1484,27 @@ class Dmux {
 
 // Validate system requirements before starting
 (async () => {
+  // Answer these before touching tmux: otherwise `dmux --version` starts the
+  // full TUI and creates a session for whatever directory it was run from.
+  const args = process.argv.slice(2);
+  if (args.includes('--version') || args.includes('-v')) {
+    console.log(packageJson.version);
+    process.exit(0);
+  }
+  if (args.includes('--help') || args.includes('-h')) {
+    console.log(`dmux ${packageJson.version}
+
+Usage: dmux [options]
+
+Options:
+  -v, --version                 Print the version and exit
+  -h, --help                    Print this help and exit
+      --files-only              Open the file browser instead of the session UI
+      --remote-pane-action <s>  Queue a pane action against the running controller
+`);
+    process.exit(0);
+  }
+
   if (isFilesOnlyMode()) {
     render(React.createElement(FileBrowserApp), { exitOnCtrlC: false });
     return;


### PR DESCRIPTION
`--version` and `--help` are not recognised anywhere in the entry point, so they fall through to the normal startup path. `dmux --version` therefore renders the full TUI and creates a tmux session for whatever directory it happened to run in — I hit this while scripting against dmux and had to clean up a stray `dmux-homebrew-*` session afterwards.

This answers both flags at the top of the entry IIFE (`src/index.ts:1486`), before `validateSystemRequirements()` and before anything touches tmux, reusing the `packageJson` import already present at `:80`.

Verified against the built output:

```
$ node dist/index.js --version
5.10.0
$ node dist/index.js --help
dmux 5.10.0
...
```

with `tmux ls` showing the same session count before and after both invocations.

`pnpm typecheck` clean; suite unchanged (the one failure is the pre-existing stale `generateCommitMessage` test, fixed in #103).