### PR TITLE
fix: move resize signal handling out of the React effect

### DIFF
--- a/__tests__/noSignalHandlersInHooks.test.ts
+++ b/__tests__/noSignalHandlersInHooks.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync, statSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const hooksDir = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../src/hooks'
+);
+
+function sourceFiles(dir: string): string[] {
+  return readdirSync(dir).flatMap(entry => {
+    const full = path.join(dir, entry);
+    if (statSync(full).isDirectory()) return sourceFiles(full);
+    return /\.tsx?$/.test(entry) ? [full] : [];
+  });
+}
+
+// Only OS signals matter. process.on('pane-split-detected') and friends are
+// custom events with no default disposition, so they stay legal here.
+const OS_SIGNAL = /process\.on\(\s*['"`](SIG[A-Z0-9]+)['"`]/g;
+
+/**
+ * Registering an OS signal listener inside a React effect is a trap: the effect
+ * cleanup calls process.off, and once the last listener for a signal is removed
+ * Node restores the default disposition — which for SIGUSR1/SIGHUP/SIGTERM means
+ * terminate. A signal arriving between cleanup and re-registration then kills
+ * dmux. Signal handlers belong at process scope, next to the ones in index.ts.
+ */
+describe('src/hooks must not register OS signal handlers', () => {
+  it('has no process.on("SIG…") inside any hook', () => {
+    const offenders: string[] = [];
+
+    for (const file of sourceFiles(hooksDir)) {
+      const source = readFileSync(file, 'utf8');
+      for (const match of source.matchAll(OS_SIGNAL)) {
+        const line = source.slice(0, match.index).split('\n').length;
+        offenders.push(`${path.relative(hooksDir, file)}:${line} registers ${match[1]}`);
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/src/hooks/useLayoutManagement.ts
+++ b/src/hooks/useLayoutManagement.ts
@@ -93,15 +93,17 @@ export function useLayoutManagement({
     // Listen to stdout resize events
     process.stdout.on('resize', handleResize);
 
-    // Also listen for SIGWINCH and SIGUSR1 (tmux hook sends USR1)
-    process.on('SIGWINCH', handleResize);
-    process.on('SIGUSR1', handleResize);
+    // SIGWINCH and the tmux client-resized SIGUSR1 are handled at process scope
+    // in index.ts, which re-emits them as this event. Subscribing to the signals
+    // directly from here would be fatal: this effect re-runs on every dialog
+    // toggle, and once its cleanup removes the last listener for a signal Node
+    // restores the default disposition, which for SIGUSR1 is terminate.
+    process.on('dmux-resize-requested' as any, handleResize);
 
     return () => {
       isMountedRef.current = false;
       process.stdout.off('resize', handleResize);
-      process.off('SIGWINCH', handleResize);
-      process.off('SIGUSR1', handleResize);
+      process.off('dmux-resize-requested' as any, handleResize);
       if (resizeTimeoutRef.current) {
         clearTimeout(resizeTimeoutRef.current);
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1459,6 +1459,17 @@ class Dmux {
       cleanTerminalExit('SIGTERM');
     });
 
+    // Resize signals live here, not in useLayoutManagement: that hook re-runs on
+    // every dialog toggle, and once its cleanup removed the last listener Node
+    // restored the default disposition for SIGUSR1 — terminate — so a resize at
+    // the wrong moment killed the control pane.
+    const requestResize = () => {
+      process.emit('dmux-resize-requested' as any);
+    };
+    process.on('SIGWINCH', requestResize);
+    // Sent by the tmux client-resized hook installed in setupResizeHook().
+    process.on('SIGUSR1', requestResize);
+
     // Handle SIGUSR2 for pane split detection
     // This signal is sent by tmux hook when a new pane is created
     process.on('SIGUSR2', () => {


### PR DESCRIPTION
**Supersedes #102** — same bug, better fix. Please take this one instead.

`useLayoutManagement` registers `SIGWINCH` and `SIGUSR1` inside a `useEffect` whose deps include `hasActiveDialog` (`src/hooks/useLayoutManagement.ts:97-98`, cleanup at `:103-104`). Node restores a signal's default disposition once the last JS listener is removed, and for `SIGUSR1` that default is terminate — so every dialog toggle opens a window in which the `client-resized` hook dmux installs on itself kills the control pane.

#102 papered over this with a permanent no-op listener. This instead moves both signals to process scope, next to the existing `SIGUSR2` handler, and has them re-emit `dmux-resize-requested` — exactly the pattern `pane-split-detected` already uses (`src/index.ts:1464` → `src/hooks/usePanes.ts:349`). `useLayoutManagement` subscribes to that event instead, keeping all resize logic where it is.

Why it's intermittent, since it confused me for a while: a process that never registered a JS listener *survives* `SIGUSR1` — Node reserves it for the inspector. Only the add-then-remove cycle restores the fatal default. So dmux is safe until this effect first mounts and cleans up, and vulnerable after.

### Guard

`__tests__/noSignalHandlersInHooks.test.ts` fails if any file under `src/hooks/` registers `process.on('SIG…')`. It matches OS signal names only, so the custom-event listeners in `usePanes.ts` and `useInputHandling.ts` stay legal. Against unpatched `main` it reports exactly the two offending lines.

### Verification

- Guard test passes; `pnpm typecheck` clean.
- Suite: `109 passed | 1 skipped`, the single failure being the pre-existing stale `generateCommitMessage` test fixed in #103.
- Functional: dmux started in an isolated tmux server survives 5 consecutive `SIGUSR1`.