### PR TITLE
fix: guard hook signals on the PID still being dmux

### DIFF
--- a/__tests__/tmuxHookCommands.test.ts
+++ b/__tests__/tmuxHookCommands.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  buildGuardedSignalCommand,
   buildPaneExitedHookCommandForSession,
   buildPaneFocusHookCommandForSession,
 } from '../src/utils/tmuxHookCommands.js';
@@ -29,7 +30,30 @@ describe('tmuxHookCommands', () => {
     expect(command).toContain('if-shell -F "#{!=:#{@dmux_active_border_style},}"');
     expect(command).toContain('set-option -F -t \\"my\\"session\\$\\`x\\\\y\\" pane-active-border-style');
     expect(command).toContain('#{@dmux_active_border_style}');
-    expect(command).toContain('run-shell -b "kill -USR2 99 2>/dev/null || true # dmux-hook"');
+    expect(command).toContain('kill -USR2 99 2>/dev/null || true # dmux-hook"');
     expect(command).not.toContain('show-options -p -v');
+  });
+
+  it('guards the signal on the PID still being this dmux process', () => {
+    const command = buildGuardedSignalCommand(4321, 'USR1');
+
+    // A hook that outlives dmux would otherwise signal whatever inherits the
+    // recycled PID, and SIGUSR1 defaults to terminate.
+    expect(command).toContain('ps -p 4321 -o command=');
+    expect(command).toContain('grep -qF');
+    expect(command).toContain(process.argv[1]!);
+    expect(command).toContain('kill -USR1 4321');
+  });
+
+  it('falls back to a bare kill when the entry path is unknown', () => {
+    const previous = process.argv[1];
+    // @ts-expect-error - deliberately simulating an unknown entry path
+    process.argv[1] = undefined;
+
+    try {
+      expect(buildGuardedSignalCommand(7, 'USR2')).toBe('kill -USR2 7 2>/dev/null || true');
+    } finally {
+      process.argv[1] = previous;
+    }
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ import { atomicWriteJson } from './utils/atomicWrite.js';
 import { buildDevWatchCommand, buildDevWatchRespawnCommand } from './utils/devWatchCommand.js';
 import { shouldUseQuietDevWatchExit } from './utils/devWatchExit.js';
 import {
+  buildGuardedSignalCommand,
   buildPaneExitedHookCommandForSession,
   buildPaneFocusHookCommandForSession,
 } from './utils/tmuxHookCommands.js';
@@ -1323,7 +1324,8 @@ class Dmux {
       // Set up session-specific hook that sends SIGUSR1 to dmux process on resize
       // This works inside tmux where normal SIGWINCH may not propagate
       const pid = process.pid;
-      execSync(`tmux set-hook -t '${sessionName}' client-resized 'run-shell "kill -USR1 ${pid} 2>/dev/null || true"'`, { stdio: 'pipe' });
+      const notify = buildGuardedSignalCommand(pid, 'USR1').replace(/[\\$"`]/g, '\\$&');
+      execSync(`tmux set-hook -t '${sessionName}' client-resized 'run-shell "${notify}"'`, { stdio: 'pipe' });
       // LogService.getInstance().debug(`Set up resize hook for session ${this.sessionName}`, 'Setup');
     } catch (error) {
       LogService.getInstance().warn('Failed to set up resize hook', 'Setup');

--- a/src/utils/tmuxHookCommands.ts
+++ b/src/utils/tmuxHookCommands.ts
@@ -8,6 +8,32 @@ function escapeForDoubleQuotes(value: string): string {
 }
 
 /**
+ * Builds a `kill -SIG<name> <pid>` that first confirms the PID still belongs to
+ * this dmux process.
+ *
+ * tmux hooks outlive the process that installed them whenever dmux dies without
+ * running its teardown. PIDs get recycled, so an unguarded hook eventually
+ * delivers the signal to an unrelated process — and SIGUSR1's default
+ * disposition is terminate, so that process dies on the next resize.
+ *
+ * The guard matches the full entry-script path rather than the string "dmux",
+ * which would also match an editor that happens to have a dmux source file
+ * open. If the entry path is unavailable we emit the bare kill: a hook that
+ * never fires would be worse than one that can misfire.
+ */
+export function buildGuardedSignalCommand(pid: number, signal: 'USR1' | 'USR2'): string {
+  const kill = `kill -${signal} ${pid} 2>/dev/null || true`;
+  const entryPath = process.argv[1];
+
+  if (!entryPath) {
+    return kill;
+  }
+
+  const quotedEntry = `'${entryPath.replace(/'/g, `'\\''`)}'`;
+  return `ps -p ${pid} -o command= 2>/dev/null | grep -qF ${quotedEntry} && ${kill}`;
+}
+
+/**
  * Builds the pane-exited hook command used by dmux.
  *
  * It performs two actions:
@@ -17,7 +43,8 @@ function escapeForDoubleQuotes(value: string): string {
 export function buildPaneExitedHookCommand(pid: number): string {
   const recoveryScriptPath = resolveDistPath('utils', 'controlPaneRecovery.js');
   const escapedScriptPath = escapeForDoubleQuotes(recoveryScriptPath);
-  return `run-shell "DMUX_RECOVERY_EXITED_PANE=#{hook_pane} node \\"${escapedScriptPath}\\" >/dev/null 2>&1; kill -USR2 ${pid} 2>/dev/null || true # dmux-hook"`;
+  const notify = escapeForDoubleQuotes(buildGuardedSignalCommand(pid, 'USR2'));
+  return `run-shell "DMUX_RECOVERY_EXITED_PANE=#{hook_pane} node \\"${escapedScriptPath}\\" >/dev/null 2>&1; ${notify} # dmux-hook"`;
 }
 
 /**
@@ -31,8 +58,9 @@ export function buildPaneExitedHookCommandForSession(
   const recoveryScriptPath = resolveDistPath('utils', 'controlPaneRecovery.js');
   const escapedScriptPath = escapeForDoubleQuotes(recoveryScriptPath);
   const encodedSessionName = Buffer.from(sessionName, 'utf-8').toString('base64');
+  const notify = escapeForDoubleQuotes(buildGuardedSignalCommand(pid, 'USR2'));
 
-  return `run-shell "DMUX_RECOVERY_SESSION_B64=${encodedSessionName} DMUX_RECOVERY_EXITED_PANE=#{hook_pane} node \\"${escapedScriptPath}\\" >/dev/null 2>&1; kill -USR2 ${pid} 2>/dev/null || true # dmux-hook"`;
+  return `run-shell "DMUX_RECOVERY_SESSION_B64=${encodedSessionName} DMUX_RECOVERY_EXITED_PANE=#{hook_pane} node \\"${escapedScriptPath}\\" >/dev/null 2>&1; ${notify} # dmux-hook"`;
 }
 
 /**
@@ -46,7 +74,7 @@ export function buildPaneFocusHookCommandForSession(
 ): string {
   const escapedSessionName = escapeForDoubleQuotes(sessionName);
   const notifyController = typeof pid === 'number'
-    ? `; run-shell -b "kill -USR2 ${pid} 2>/dev/null || true # dmux-hook"`
+    ? `; run-shell -b "${escapeForDoubleQuotes(buildGuardedSignalCommand(pid, 'USR2'))} # dmux-hook"`
     : '';
 
   return `if-shell -F "#{!=:#{@dmux_active_border_style},}" "set-option -F -t \\"${escapedSessionName}\\" pane-active-border-style \\"#{@dmux_active_border_style}\\""${notifyController}`;


### PR DESCRIPTION
The `client-resized`, `after-select-pane` and `pane-exited` hooks bake a PID into a `kill`. If dmux ever dies without running its teardown, the hooks stay installed in the tmux server and keep firing at that PID — which the OS eventually hands to an unrelated process. Since `SIGUSR1`'s default disposition is terminate, that process then dies on the next terminal resize.

I hit the dangling-hook state on three sessions and had to clear them by hand; the PID counter was ~40k away from wrapping onto them.

New `buildGuardedSignalCommand(pid, signal)` in `src/utils/tmuxHookCommands.ts` produces:

```sh
ps -p 12345 -o command= 2>/dev/null | grep -qF '/path/to/dmux/dist/index.js' && kill -USR1 12345 2>/dev/null || true
```

and is used by all four hook sites (the three builders in that module plus `setupResizeHook` in `src/index.ts`).

Two deliberate choices:

- **Match the entry-script path, not the string `dmux`.** A bare `grep -q dmux` would also match an editor that happens to have a dmux source file open, and would then kill it.
- **Fail open.** If `process.argv[1]` is unavailable we emit the bare `kill`; a hook that never fires would be worse than one that can misfire.

### Verification

Both directions tested against a live process:

- A foreign process holding the target PID survives the guarded command.
- A process whose command line contains the entry path receives the signal (`SIGNAL_RECEIVED`, exit 7).

`pnpm typecheck` clean. `__tests__/tmuxHookCommands.test.ts` extended with the guard and the fail-open fallback — 5 passed. Suite otherwise unchanged (the one failure is the pre-existing stale `generateCommitMessage` test, fixed in #103).