### PR TITLE
fix: run tmux teardown when Ink exits

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -670,8 +670,20 @@ class Dmux {
       ...(mouseFilter ? { stdin: mouseFilter.stdin } : {}),
     });
 
-    // Clean shutdown on app exit
+    // Clean shutdown on app exit.
+    // exitOnCtrlC is false and the app handles Ctrl+C itself, so quitting that way
+    // unmounts Ink without ever raising SIGINT — the signal handler's teardown never
+    // runs. Repeat it here, or the session keeps tmux hooks aimed at a PID that is
+    // about to be recycled. claimProcessShutdown keeps the two paths exclusive.
     app.waitUntilExit().then(async () => {
+      if (process.env.TMUX && claimProcessShutdown('ink-exit')) {
+        this.cleanupResizeHook();
+        this.cleanupPaneSplitHook();
+        this.cleanupPaneFocusHook();
+        this.clearRemotePaneModeIndicators();
+        this.cleanupRemotePaneActionBindings();
+        this.cleanupSessionRuntimeMetadata();
+      }
       if (mouseFilter) {
         process.stdout.write(MOUSE_REPORTING_DISABLE);
         mouseFilter.detach();


### PR DESCRIPTION
Quitting dmux with its own Ctrl+C leaves the session's tmux hooks installed.

`render()` is called with `exitOnCtrlC: false` (`src/index.ts:670`) and the app handles the key itself — `FooterHelp.tsx:36` prints *Press Ctrl+C again to exit*, handled in `useInputHandling.ts:1212`. So quitting unmounts Ink **without ever raising SIGINT**, and `cleanTerminalExit` never runs.

The Ink exit path (`src/index.ts:673`) only reset mouse reporting and called `process.exit(0)`. Compare with the signal path (`:1421-1426`), which also removes the resize / pane-split / pane-focus hooks, the remote-pane bindings and the session runtime metadata. Net effect: after a normal Ctrl+C quit, `tmux show-hooks` still lists `kill -USR1 <pid>` / `kill -USR2 <pid>` for a dead PID — and since PIDs are recycled, an unrelated process later gets those signals on resize (SIGUSR1 defaults to terminate).

This repeats the same teardown on the Ink exit path, guarded by the existing `claimProcessShutdown` so the two paths stay exclusive.

Reported by a user who hit it reliably: *"it happens when I switch to the left pane and press Ctrl+C to quit"*. It matches the dangling hooks I kept finding on that machine.

### Verification — what is and isn't proven

`pnpm typecheck` clean; suite unchanged (the one failure is the pre-existing stale `generateCommitMessage` test, fixed in #103).

**Not verified end to end.** I tried an A/B in a detached tmux server and it was inconclusive: both the patched and unpatched builds ended with zero hooks, which means the harness exercised the SIGINT path rather than the app's own key handling — a detached pane does not reproduce the interactive raw-mode quit. I am reporting that rather than dressing it up. The change is justified by the code paths above, not by a passing test; if you would rather see a regression test first, say so and I will find a harness that genuinely reaches the Ink exit.

Complements #104 (SIGHUP): together they close both routes by which dmux currently exits without teardown.